### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -2,6 +2,9 @@ name: badges
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   go_badges:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/richardwooding/feed-mcp/security/code-scanning/2](https://github.com/richardwooding/feed-mcp/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow only generates badges and does not appear to require write access, we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
