### PR TITLE
docs: update README and copilot instructions to reflect official MCP Go SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 - **Feed Logic**: Handled in `model` (data structures, conversion) and `store` (fetching, caching, error handling) packages.
 - **Caching**: Uses [`gocache`](https://github.com/eko/gocache) and [`ristretto`](https://github.com/dgraph-io/ristretto) for in-memory feed caching.
 - **Feed Parsing**: [`gofeed`](https://github.com/mmcdole/gofeed`) parses RSS/Atom/JSON feeds.
-- **Protocol Layer**: `mcpserver` handles the MCP protocol with [`mcp-go`](https://github.com/mark3labs/mcp-go).
+- **Protocol Layer**: `mcpserver` handles the MCP protocol with the [official MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk).
 - **Tests**: All core logic is tested, with test files named `*_test.go` (see `main_test.go`, `store/store_test.go`, etc).
 
 ## Go Conventions & Patterns

--- a/README.md
+++ b/README.md
@@ -15,19 +15,14 @@ MCP Server for RSS, Atom, and JSON Feeds
 - Supports multiple feeds simultaneously
 - Extensible and configurable
 
-## Switching to official MCP Go SDK
-
-- I am planning to switch tho the official [MCP Go SDK](https://github.com/orgs/modelcontextprotocol/discussions/364)
-  when it is ready for production use.
-
 ## Architecture
 
-The core of `feed-mcp` is a Go server that fetches, parses, and serves RSS/Atom/JSON feeds over the [MCP protocol](https://github.com/mark3labs/mcp-go). The main architectural components are:
+The core of `feed-mcp` is a Go server that fetches, parses, and serves RSS/Atom/JSON feeds over the [MCP protocol](https://spec.modelcontextprotocol.io/specification/). The main architectural components are:
 
 - **Command-line Interface (CLI):** Uses [kong](https://github.com/alecthomas/kong) for parsing commands and flags. The `run` command is the entry point for starting the server.
 - **Feed Fetching & Parsing:** Feeds are fetched and parsed using [gofeed](https://github.com/mmcdole/gofeed). The server supports multiple feeds, which are periodically refreshed and cached.
 - **Caching Layer:** Feed data is cached using [gocache](https://github.com/eko/gocache) and [ristretto](https://github.com/dgraph-io/ristretto) for efficient retrieval and reduced network usage.
-- **MCP Protocol Server:** Implements the MCP protocol using [mcp-go](https://github.com/mark3labs/mcp-go), allowing integration with clients like Claude Desktop.
+- **MCP Protocol Server:** Implements the MCP protocol using the [official MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk), allowing integration with clients like Claude Desktop.
 - **Transport Options:** Supports different transports (e.g., stdio, HTTP with SSE) for communication with MCP clients.
 - **Docker/Podman Support:** The server can be run in containers for easy deployment and integration.
 
@@ -122,7 +117,7 @@ This project makes use of the following open source libraries:
 - [kong](https://github.com/alecthomas/kong) — Command-line parser
 - [gocache](https://github.com/eko/gocache) — Caching library
 - [ristretto](https://github.com/dgraph-io/ristretto) — High performance cache
-- [mcp-go](https://github.com/mark3labs/mcp-go) — MCP protocol implementation
+- [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk) — Official MCP protocol implementation
 
 ## License
 


### PR DESCRIPTION
This PR updates the documentation to accurately reflect the current state of the codebase after the migration to the official MCP Go SDK.

## Changes

### README.md
- ✅ Remove outdated section about planning to switch to official MCP Go SDK (migration is complete)
- ✅ Update MCP protocol link from old mcp-go repository to official MCP specification
- ✅ Update MCP Protocol Server description to reference official MCP Go SDK
- ✅ Update Dependencies section to list "MCP Go SDK" as "Official MCP protocol implementation"

### .github/copilot-instructions.md
- ✅ Update Protocol Layer description to reference official MCP Go SDK instead of third-party mcp-go

## Context

The codebase has already been successfully migrated to use `github.com/modelcontextprotocol/go-sdk v0.2.0` (as shown in go.mod), but the documentation still referenced the old third-party `mcp-go` library. This PR brings the documentation in sync with the actual implementation.

## Testing

- Documentation changes only
- All existing functionality remains unchanged
- Links have been verified to point to correct resources