### PR TITLE
docs: add MCP badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Coverage](https://github.com/richardwooding/feed-mcp/wiki/coverage.svg)](https://raw.githack.com/wiki/richardwooding/feed-mcp/coverage.html)
 [![Go Report Card](https://goreportcard.com/badge/github.com/richardwooding/feed-mcp)](https://goreportcard.com/report/github.com/richardwooding/feed-mcp)
+[![MCP Badge](https://lobehub.com/badge/mcp/richardwooding-feed-mcp)](https://lobehub.com/mcp/richardwooding-feed-mcp)
 
 MCP Server for RSS, Atom, and JSON Feeds
 


### PR DESCRIPTION
## Summary
- Add MCP badge from lobehub.com to the README badges section

## Test plan
- [x] Verify badge displays correctly in README
- [x] Verify badge links to the correct MCP page

🤖 Generated with [Claude Code](https://claude.ai/code)