### PR TITLE
feat: enable circuit breaker by default with configurable failure threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Add any of these configurations to your Claude Desktop to instantly access the l
 - Compatible with Claude Desktop as an MCP server
 - Caching for efficient feed retrieval
 - Built-in rate limiting (2 req/s default) to be respectful to feed servers
+- Circuit breaker pattern for fault tolerance against failing feeds
 - Supports multiple feeds simultaneously
 - Extensible and configurable
 
@@ -74,6 +75,7 @@ The core of `feed-mcp` is a Go server that fetches, parses, and serves RSS/Atom/
 - **Feed Fetching & Parsing:** Feeds are fetched and parsed using [gofeed](https://github.com/mmcdole/gofeed). The server supports multiple feeds, which are periodically refreshed and cached.
 - **Caching Layer:** Feed data is cached using [gocache](https://github.com/eko/gocache) and [ristretto](https://github.com/dgraph-io/ristretto) for efficient retrieval and reduced network usage.
 - **Rate Limiting:** Built-in HTTP rate limiting using [golang.org/x/time/rate](https://pkg.go.dev/golang.org/x/time/rate) prevents overwhelming feed servers with requests.
+- **Circuit Breaker:** Implements circuit breaker pattern using [sony/gobreaker](https://github.com/sony/gobreaker) to temporarily stop fetching from consistently failing feeds, with configurable failure thresholds and recovery timeouts.
 - **MCP Protocol Server:** Implements the MCP protocol using the [official MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk), allowing integration with clients like Claude Desktop.
 - **Transport Options:** Supports different transports (e.g., stdio, HTTP with SSE) for communication with MCP clients.
 - **Docker/Podman Support:** The server can be run in containers for easy deployment and integration.
@@ -170,6 +172,7 @@ This project makes use of the following open source libraries:
 - [gocache](https://github.com/eko/gocache) — Caching library
 - [ristretto](https://github.com/dgraph-io/ristretto) — High performance cache
 - [golang.org/x/time/rate](https://pkg.go.dev/golang.org/x/time/rate) — Token bucket rate limiter
+- [sony/gobreaker](https://github.com/sony/gobreaker) — Circuit breaker pattern implementation
 - [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk) — Official MCP protocol implementation
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/prometheus/common v0.52.3 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
+	github.com/sony/gobreaker v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/temoto/robotstxt v1.1.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/prometheus/procfs v0.13.0/go.mod h1:cd4PFCR54QLnGKPaKGA6l+cfuNXtht43Z
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7AwssoOcM/tq5JjjG2yYOc8odClEiXA=
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
+github.com/sony/gobreaker v1.0.0 h1:feX5fGGXSl3dYd4aHZItw+FpHLvvoaqkawKjVNiFMNQ=
+github.com/sony/gobreaker v1.0.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=

--- a/model/feedanditemsresult.go
+++ b/model/feedanditemsresult.go
@@ -5,10 +5,11 @@ import (
 )
 
 type FeedAndItemsResult struct {
-	ID         string         `json:"id"`
-	PublicURL  string         `json:"public_url"`
-	Title      string         `json:"title,omitempty"`
-	FetchError string         `json:"fetch_error,omitempty"`
-	Feed       *Feed          `json:"feed_result,omitempty"`
-	Items      []*gofeed.Item `json:"items,omitempty"`
+	ID                 string         `json:"id"`
+	PublicURL          string         `json:"public_url"`
+	Title              string         `json:"title,omitempty"`
+	FetchError         string         `json:"fetch_error,omitempty"`
+	Feed               *Feed          `json:"feed_result,omitempty"`
+	Items              []*gofeed.Item `json:"items,omitempty"`
+	CircuitBreakerOpen bool           `json:"circuit_breaker_open,omitempty"`
 }

--- a/model/feedresult.go
+++ b/model/feedresult.go
@@ -1,9 +1,10 @@
 package model
 
 type FeedResult struct {
-	ID         string `json:"id"`
-	PublicURL  string `json:"public_url"`
-	Title      string `json:"title,omitempty"`
-	FetchError string `json:"fetch_error,omitempty"`
-	Feed       *Feed  `json:"feed,omitempty"`
+	ID                 string `json:"id"`
+	PublicURL          string `json:"public_url"`
+	Title              string `json:"title,omitempty"`
+	FetchError         string `json:"fetch_error,omitempty"`
+	Feed               *Feed  `json:"feed,omitempty"`
+	CircuitBreakerOpen bool   `json:"circuit_breaker_open,omitempty"`
 }

--- a/store/store.go
+++ b/store/store.go
@@ -131,15 +131,13 @@ func NewStore(config Config) (*Store, error) {
 	if circuitBreakerEnabled {
 		circuitBreakers = make(map[string]*gobreaker.CircuitBreaker)
 		for _, feedURL := range config.Feeds {
-			// Capture the failure threshold for this closure
-			failureThreshold := config.CircuitBreakerFailureThreshold
 			settings := gobreaker.Settings{
 				Name:        fmt.Sprintf("feed-%s", feedURL),
 				MaxRequests: config.CircuitBreakerMaxRequests,
 				Interval:    config.CircuitBreakerInterval,
 				Timeout:     config.CircuitBreakerTimeout,
 				ReadyToTrip: func(counts gobreaker.Counts) bool {
-					return counts.ConsecutiveFailures >= failureThreshold
+					return counts.ConsecutiveFailures >= config.CircuitBreakerFailureThreshold
 				},
 			}
 			circuitBreakers[feedURL] = gobreaker.NewCircuitBreaker(settings)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -308,3 +308,394 @@ func TestStore_CustomHttpClientPreserved(t *testing.T) {
 		t.Errorf("expected Title 'CustomClientTest', got %q", results[0].Title)
 	}
 }
+
+func TestStore_CircuitBreakerDisabled(t *testing.T) {
+	srv := mockFeedServer(t, "CircuitBreakerTest")
+	defer srv.Close()
+
+	// Create store with circuit breaker explicitly disabled
+	disabled := false
+	store, err := NewStore(Config{
+		Feeds:                 []string{srv.URL},
+		CircuitBreakerEnabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	// Verify circuit breaker is not initialized
+	if store.circuitBreakers != nil {
+		t.Error("expected circuitBreakers to be nil when disabled")
+	}
+
+	ctx := context.Background()
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// Circuit breaker should not be open since it's disabled
+	if results[0].CircuitBreakerOpen {
+		t.Error("expected CircuitBreakerOpen to be false when circuit breaker is disabled")
+	}
+}
+
+func TestStore_CircuitBreakerEnabledByDefault(t *testing.T) {
+	srv := mockFeedServer(t, "CircuitBreakerTest")
+	defer srv.Close()
+
+	// Create store without specifying circuit breaker setting - should be enabled by default
+	store, err := NewStore(Config{
+		Feeds:                 []string{srv.URL},
+		CircuitBreakerTimeout: 1 * time.Second, // Short timeout for testing
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	// Verify circuit breaker is initialized by default
+	if store.circuitBreakers == nil {
+		t.Fatal("expected circuitBreakers to be initialized by default")
+	}
+
+	if cb, exists := store.circuitBreakers[srv.URL]; !exists {
+		t.Fatal("expected circuit breaker to exist for feed URL")
+	} else if cb == nil {
+		t.Fatal("expected circuit breaker to be non-nil")
+	}
+
+	ctx := context.Background()
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// Circuit breaker should be closed initially
+	if results[0].CircuitBreakerOpen {
+		t.Error("expected CircuitBreakerOpen to be false initially")
+	}
+}
+
+func TestStore_CircuitBreakerExplicitlyEnabled(t *testing.T) {
+	srv := mockFeedServer(t, "CircuitBreakerTest")
+	defer srv.Close()
+
+	// Create store with circuit breaker explicitly enabled
+	enabled := true
+	store, err := NewStore(Config{
+		Feeds:                 []string{srv.URL},
+		CircuitBreakerEnabled: &enabled,
+		CircuitBreakerTimeout: 1 * time.Second, // Short timeout for testing
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	// Verify circuit breaker is initialized
+	if store.circuitBreakers == nil {
+		t.Fatal("expected circuitBreakers to be initialized when enabled")
+	}
+
+	if cb, exists := store.circuitBreakers[srv.URL]; !exists {
+		t.Fatal("expected circuit breaker to exist for feed URL")
+	} else if cb == nil {
+		t.Fatal("expected circuit breaker to be non-nil")
+	}
+
+	ctx := context.Background()
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// Circuit breaker should be closed initially
+	if results[0].CircuitBreakerOpen {
+		t.Error("expected CircuitBreakerOpen to be false initially")
+	}
+}
+
+func TestStore_CircuitBreakerFailures(t *testing.T) {
+	// Create a server that fails consistently
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failingServer.Close()
+
+	// Create store with circuit breaker enabled and aggressive settings
+	enabled := true
+	store, err := NewStore(Config{
+		Feeds:                 []string{failingServer.URL},
+		CircuitBreakerEnabled: &enabled,
+		CircuitBreakerTimeout: 1 * time.Second,
+		ExpireAfter:           1 * time.Millisecond, // Force cache expiry
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Make multiple requests to trigger circuit breaker
+	for i := 0; i < 5; i++ {
+		results, err := store.GetAllFeeds(ctx)
+		if err != nil {
+			t.Fatalf("GetAllFeeds failed on attempt %d: %v", i+1, err)
+		}
+
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result on attempt %d, got %d", i+1, len(results))
+		}
+
+		// Should have fetch error
+		if results[0].FetchError == "" {
+			t.Errorf("expected FetchError on attempt %d", i+1)
+		}
+
+		// Clear cache to force new requests
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// After multiple failures, circuit breaker should be open
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// Circuit breaker should now be open
+	if !results[0].CircuitBreakerOpen {
+		t.Error("expected CircuitBreakerOpen to be true after multiple failures")
+	}
+}
+
+func TestStore_CircuitBreakerRecovery(t *testing.T) {
+	// Create a server that initially fails then recovers
+	var requestCount int64
+	recoveringServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt64(&requestCount, 1)
+		if count <= 3 {
+			// Fail first 3 requests
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Succeed after that
+		w.Header().Set("Content-Type", "application/rss+xml")
+		w.Write([]byte(`
+			<rss version="2.0">
+				<channel>
+					<title>Recovered Feed</title>
+					<item>
+						<title>Recovery Item</title>
+						<link>http://example.com/recovery</link>
+					</item>
+				</channel>
+			</rss>
+		`))
+	}))
+	defer recoveringServer.Close()
+
+	// Create store with circuit breaker enabled
+	enabled := true
+	store, err := NewStore(Config{
+		Feeds:                 []string{recoveringServer.URL},
+		CircuitBreakerEnabled: &enabled,
+		CircuitBreakerTimeout: 1 * time.Second, // Short timeout for quick recovery
+		ExpireAfter:           1 * time.Millisecond, // Force cache expiry
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// First 3 requests should fail and open the circuit
+	for i := 0; i < 3; i++ {
+		results, _ := store.GetAllFeeds(ctx)
+		if len(results) > 0 && results[0].FetchError == "" {
+			t.Errorf("expected failure on request %d", i+1)
+		}
+		time.Sleep(2 * time.Millisecond) // Clear cache
+	}
+
+	// Wait for circuit breaker timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Next request should succeed and close the circuit
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed after recovery: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result after recovery, got %d", len(results))
+	}
+
+	// Should eventually succeed
+	maxAttempts := 3
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if results[0].FetchError == "" && results[0].Title == "Recovered Feed" {
+			break
+		}
+		if attempt == maxAttempts-1 {
+			t.Errorf("expected recovery after %d attempts, got FetchError: %q, Title: %q",
+				maxAttempts, results[0].FetchError, results[0].Title)
+		}
+		time.Sleep(100 * time.Millisecond)
+		results, _ = store.GetAllFeeds(ctx)
+		if len(results) == 0 {
+			continue
+		}
+	}
+}
+
+func TestStore_CircuitBreakerCustomSettings(t *testing.T) {
+	srv := mockFeedServer(t, "CustomSettingsTest")
+	defer srv.Close()
+
+	// Create store with custom circuit breaker settings
+	enabled := true
+	store, err := NewStore(Config{
+		Feeds:                          []string{srv.URL},
+		CircuitBreakerEnabled:          &enabled,
+		CircuitBreakerMaxRequests:      5,
+		CircuitBreakerInterval:         2 * time.Second,
+		CircuitBreakerTimeout:          3 * time.Second,
+		CircuitBreakerFailureThreshold: 2, // Custom failure threshold
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	// Verify settings are applied
+	if _, exists := store.circuitBreakers[srv.URL]; !exists {
+		t.Fatal("expected circuit breaker to exist")
+	}
+
+	// We can't directly access the settings, but we can verify the circuit breaker works
+	ctx := context.Background()
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Title != "CustomSettingsTest" {
+		t.Errorf("expected Title 'CustomSettingsTest', got %q", results[0].Title)
+	}
+}
+
+func TestStore_CircuitBreakerCustomFailureThreshold(t *testing.T) {
+	// Create a server that fails consistently
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failingServer.Close()
+
+	// Create store with custom failure threshold of 2 failures
+	enabled := true
+	store, err := NewStore(Config{
+		Feeds:                          []string{failingServer.URL},
+		CircuitBreakerEnabled:          &enabled,
+		CircuitBreakerTimeout:          1 * time.Second,
+		CircuitBreakerFailureThreshold: 2, // Should open after 2 failures instead of default 3
+		ExpireAfter:                    1 * time.Millisecond, // Force cache expiry
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Make 2 requests - should be enough to trigger circuit breaker with threshold of 2
+	for i := 0; i < 2; i++ {
+		results, err := store.GetAllFeeds(ctx)
+		if err != nil {
+			t.Fatalf("GetAllFeeds failed on attempt %d: %v", i+1, err)
+		}
+
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result on attempt %d, got %d", i+1, len(results))
+		}
+
+		// Should have fetch error
+		if results[0].FetchError == "" {
+			t.Errorf("expected FetchError on attempt %d", i+1)
+		}
+
+		// Clear cache to force new requests
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// After 2 failures with threshold of 2, circuit breaker should be open
+	results, err := store.GetAllFeeds(ctx)
+	if err != nil {
+		t.Fatalf("GetAllFeeds failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// Circuit breaker should now be open with only 2 failures
+	if !results[0].CircuitBreakerOpen {
+		t.Error("expected CircuitBreakerOpen to be true after 2 failures with threshold of 2")
+	}
+}
+
+func TestGetFeedAndItems_CircuitBreakerState(t *testing.T) {
+	srv := mockFeedServer(t, "FeedAndItemsCircuitTest")
+	defer srv.Close()
+
+	// Create store with circuit breaker enabled (should be default, but let's be explicit for this test)
+	enabled := true
+	store, err := NewStore(Config{
+		Feeds:                 []string{srv.URL},
+		CircuitBreakerEnabled: &enabled,
+	})
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	// Find the ID for the feed
+	var id string
+	for k := range store.feeds {
+		id = k
+		break
+	}
+	if id == "" {
+		t.Fatal("no feed ID found")
+	}
+
+	ctx := context.Background()
+	result, err := store.GetFeedAndItems(ctx, id)
+	if err != nil {
+		t.Fatalf("GetFeedAndItems failed: %v", err)
+	}
+
+	// Circuit breaker should be closed initially
+	if result.CircuitBreakerOpen {
+		t.Error("expected CircuitBreakerOpen to be false initially")
+	}
+
+	if result.Title != "FeedAndItemsCircuitTest" {
+		t.Errorf("expected Title 'FeedAndItemsCircuitTest', got %q", result.Title)
+	}
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -495,7 +495,7 @@ func TestStore_CircuitBreakerRecovery(t *testing.T) {
 		}
 		// Succeed after that
 		w.Header().Set("Content-Type", "application/rss+xml")
-		w.Write([]byte(`
+		_, err := w.Write([]byte(`
 			<rss version="2.0">
 				<channel>
 					<title>Recovered Feed</title>
@@ -506,6 +506,9 @@ func TestStore_CircuitBreakerRecovery(t *testing.T) {
 				</channel>
 			</rss>
 		`))
+		if err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
 	}))
 	defer recoveringServer.Close()
 


### PR DESCRIPTION
## Summary

This PR implements the circuit breaker pattern for handling failing feeds with improved defaults and full configurability, resolving issue #16.

**Key Changes:**
- ✅ **Enable circuit breaker by default** for better fault tolerance out of the box
- ✅ **Add configurable failure threshold** (`CircuitBreakerFailureThreshold`) instead of hardcoded value  
- ✅ **Improved configuration API** using `*bool` to distinguish explicit disable from default behavior
- ✅ **Enhanced model responses** with `CircuitBreakerOpen` field in feed results
- ✅ **Comprehensive test coverage** with 8+ new test scenarios
- ✅ **Updated documentation** in README.md and CLAUDE.md

**Circuit Breaker Features:**
- **Default enabled** - no configuration required for basic fault tolerance
- **Per-feed isolation** - one failing feed doesn't affect others
- **Configurable thresholds** - customize failure count before opening circuit
- **Smart recovery** - automatic testing when feeds might have recovered
- **Fast-fail behavior** - avoid wasting resources on consistently failing feeds

**Configuration Examples:**
```go
// Default behavior (enabled with 3 failure threshold)
store := NewStore(Config{Feeds: []string{"https://example.com/feed"}})

// Custom threshold
store := NewStore(Config{
    Feeds: []string{"https://example.com/feed"}, 
    CircuitBreakerFailureThreshold: 5,
})

// Explicitly disabled
disabled := false
store := NewStore(Config{
    Feeds: []string{"https://example.com/feed"},
    CircuitBreakerEnabled: &disabled,
})
```

## Test plan

- [x] All existing tests continue to pass
- [x] New tests verify default enabled behavior
- [x] Custom failure threshold configuration tested
- [x] Circuit breaker state reporting tested
- [x] Explicit disable functionality tested
- [x] Build and compilation verified
- [x] Documentation updated and verified

🤖 Generated with [Claude Code](https://claude.ai/code)