### PR TITLE
fix: add Kong context binding to resolve CLI parameter error

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,17 +26,6 @@ func main() {
 		},
 	}
 
-	kongCtx := kong.Parse(&cli,
-		kong.Name("feed-mcp"),
-		kong.Description("A MCP server for RSS and Atom feeds"),
-		kong.UsageOnError(),
-		kong.ConfigureHelp(kong.HelpOptions{
-			Compact: true,
-		}),
-		kong.Vars{
-			"version": versionStr,
-		})
-
 	// Set up signal handling for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -50,7 +39,20 @@ func main() {
 		cancel() // Cancel context on signal
 	}()
 
+	kongCtx := kong.Parse(&cli,
+		kong.Name("feed-mcp"),
+		kong.Description("A MCP server for RSS and Atom feeds"),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			Compact: true,
+		}),
+		kong.Vars{
+			"version": versionStr,
+		},
+		kong.BindTo(ctx, (*context.Context)(nil))) // Bind the context with explicit type
+
 	// Pass the context to the command
+	// Kong will automatically inject both parameters to the Run method
 	err := kongCtx.Run(&cli.Globals, ctx)
 	kongCtx.FatalIfErrorf(err)
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical CLI error that prevented feed-mcp from running with the MCP Inspector and other tools that invoke the binary directly.

## Problem

When running `feed-mcp run <feeds>`, the following error occurred:
```
feed-mcp: error: couldn't find binding of type context.Context for parameter 1 of func(*model.Globals, context.Context) error(), use kong.Bind(context.Context)
```

## Root Cause

The Kong CLI framework couldn't inject the `context.Context` parameter into the `RunCmd.Run()` method because the context wasn't properly bound to Kong's dependency injection system with the correct type.

## Solution

1. **Moved context creation before Kong parsing** - Ensures context is available when Kong initializes
2. **Added `kong.BindTo(ctx, (*context.Context)(nil))`** - Properly binds the context to Kong's DI system with explicit type
3. **Keep both parameters in Run()** - Call `kongCtx.Run(&cli.Globals, ctx)` with both parameters

The key insight was that Kong needed `BindTo` with an explicit type pointer rather than just `Bind`, and both parameters still need to be passed to `Run()`.

## Testing

✅ Tested with direct CLI invocation: `go run main.go run <feeds>`
✅ Tested with compiled binary: `./feed-mcp run <feeds>`
✅ Tested with MCP Inspector: `npx @modelcontextprotocol/inspector ./feed-mcp run <feeds>`
✅ All existing functionality preserved
✅ Graceful shutdown still works correctly
✅ All CI/CD checks passing

## Impact

This fix is essential for:
- Running feed-mcp with the MCP Inspector for testing
- Integration with other MCP tooling
- Direct CLI usage in production environments
- Testing the new MCP Resources features in v1.0.0

🤖 Generated with [Claude Code](https://claude.ai/code)