### PR TITLE
feat: integrate mcp-server-dump for HTML documentation generation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,3 +44,51 @@ jobs:
       if: |
         github.event_name == 'push'
       continue-on-error: true
+
+    - name: Generate MCP Documentation
+      run: |
+        # Install mcp-server-dump
+        go install github.com/SPANDigital/mcp-server-dump@latest
+
+        # Create output directory
+        mkdir -p mcp-docs
+
+        # Generate HTML documentation
+        mcp-server-dump --format html --output mcp-docs/index.html ./main.go run
+
+        # Also generate JSON and Markdown for completeness
+        mcp-server-dump --format json --output mcp-docs/mcp-schema.json ./main.go run
+        mcp-server-dump --format markdown --output mcp-docs/README.md ./main.go run
+
+        echo "MCP documentation generated successfully"
+        ls -la mcp-docs/
+
+    - name: Upload MCP Documentation
+      uses: actions/upload-artifact@v4
+      with:
+        name: mcp-documentation
+        path: mcp-docs/
+        retention-days: 30
+
+    - name: Deploy MCP Docs to GitHub Pages
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+        # Create or checkout gh-pages branch
+        git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
+        git checkout gh-pages
+
+        # Clean existing content
+        git rm -rf . || true
+
+        # Copy generated docs
+        cp -r mcp-docs/* .
+
+        # Add and commit
+        git add .
+        git commit -m "Update MCP documentation from ${{ github.sha }}" || echo "No changes to commit"
+
+        # Push to gh-pages
+        git push origin gh-pages || echo "No changes to push"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,31 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate MCP Documentation for Release
+        run: |
+          # Install mcp-server-dump
+          go install github.com/SPANDigital/mcp-server-dump@latest
+
+          # Create output directory
+          mkdir -p mcp-release-docs
+
+          # Generate HTML documentation
+          mcp-server-dump --format html --output mcp-release-docs/index.html ./main.go run
+
+          # Also generate JSON and Markdown
+          mcp-server-dump --format json --output mcp-release-docs/mcp-schema.json ./main.go run
+          mcp-server-dump --format markdown --output mcp-release-docs/README.md ./main.go run
+
+          echo "MCP documentation generated for release ${{ github.ref_name }}"
+          ls -la mcp-release-docs/
+
+      - name: Upload MCP Documentation as Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            mcp-release-docs/index.html
+            mcp-release-docs/mcp-schema.json
+            mcp-release-docs/README.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Integrates [mcp-server-dump](https://github.com/SPANDigital/mcp-server-dump) into CI/CD pipeline
- Generates HTML, JSON, and Markdown documentation automatically
- Deploys documentation to GitHub Pages and attaches to releases

## Changes Made

### CI Workflow (`.github/workflows/go.yml`)
- Added step to install and run mcp-server-dump
- Generates documentation in HTML, JSON, and Markdown formats
- Uploads documentation as GitHub Actions artifacts (30-day retention)
- Deploys HTML docs to GitHub Pages on main branch pushes

### Release Workflow (`.github/workflows/release.yml`)
- Generates MCP documentation for each tagged release
- Attaches documentation files (HTML, JSON, MD) to GitHub releases

## Documentation Output
- **HTML**: Interactive web documentation at `mcp-docs/index.html`
- **JSON**: Machine-readable schema at `mcp-docs/mcp-schema.json`
- **Markdown**: Text documentation at `mcp-docs/README.md`

## Access Points
- **GitHub Pages**: Documentation will be available at `https://richardwooding.github.io/feed-mcp/`
- **CI Artifacts**: Available for download from each workflow run
- **Release Assets**: Attached to each GitHub release

## Test Plan
- [x] Workflow YAML is valid
- [ ] CI/CD pipeline runs successfully with integration
- [ ] Documentation is generated correctly
- [ ] GitHub Pages deployment works
- [ ] Release assets are attached properly

🤖 Generated with [Claude Code](https://claude.ai/code)