### PR TITLE
ci: migrate GitHub Actions to Node 24 runtime

### DIFF
--- a/.claude/skills/gh-actions-node24-migration/SKILL.md
+++ b/.claude/skills/gh-actions-node24-migration/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gh-actions-node24-migration
+description: AuditPs GitHub Actions workflows and action.yml metadata for the Node 20 to Node 24 runner deprecation, then bumps `uses:` action versions and rewrites `runs.using: node20` to `node24`. Use when reviewing or upgrading any repo's `.github/workflows/*.yml` or `action.yml`/`action.yaml`, or when the prompt mentions Node 20 deprecation, FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, or ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION.
+---
+
+# GitHub Actions Node 24 Migration
+
+GitHub is retiring the Node 20 runtime on Actions runners. The runner default flips from Node 20 to Node 24, then Node 20 is removed entirely. Two audiences must act:
+
+- **Workflow authors** — bump `uses:` references to action versions whose published `action.yml` declares Node 24.
+- **Action authors** — change `runs.using: node20` to `node24` in their action's metadata file.
+
+This skill drives that migration deterministically: a single audit script classifies every action reference in a repo, and an apply script rewrites the safe ones in place.
+
+## Quick start
+
+```sh
+# 1. Audit (read-only). Writes audit.json next to the cwd and prints a markdown table.
+python scripts/audit.py <repo-root>
+
+# 2. Review the table. Decide which findings to take.
+
+# 3. Dry-run the rewrite (default — prints unified diffs, writes nothing).
+python scripts/apply_fix.py audit.json
+
+# 4. Apply for real once the diffs look right.
+python scripts/apply_fix.py audit.json --apply
+```
+
+`gh` (GitHub CLI) must be installed and authenticated — the audit calls `gh api` to read each action's `action.yml` at its pinned ref and to discover the latest Node 24 release.
+
+## What gets audited
+
+- `**/.github/workflows/*.yml` and `*.yaml` — every `uses:` line (job steps and reusable workflows).
+- Top-level `action.yml`/`action.yaml` and any nested `**/action.yml` — the `runs.using` field.
+- Composite actions — recursed into `runs.steps[].uses`.
+
+Actions are classified into one of these states:
+
+| State            | Meaning                                                          | Auto-fixable     |
+|------------------|------------------------------------------------------------------|------------------|
+| `node24`         | Already on Node 24.                                              | —                |
+| `node20-fixable` | On Node 20; a Node 24 release exists upstream.                   | yes              |
+| `node20-stuck`   | On Node 20; no Node 24 release published yet.                    | no — flag only   |
+| `local-node20`   | Local `action.yml` declares `runs.using: node20`.                | yes (rewrite)    |
+| `composite`      | Composite action — judged by its inner `uses:` references.       | recursed         |
+| `docker`         | Docker-based action; not affected by the Node deprecation.       | skip             |
+| `unresolved`     | `action.yml` not reachable (private, archived, deleted).         | no — flag only   |
+
+For non-obvious cases — SHA pins, archived actions, the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` and `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` escape flags, reusable-workflow refs — see [references/edge-cases.md](references/edge-cases.md).
+
+## Scripts
+
+- **Run** `python scripts/audit.py <repo-root> [--out audit.json]` — walks the repo, calls `gh api` per action, prints a markdown table to stdout, and writes structured findings to `audit.json` (default path: `./audit.json`). Exits non-zero if any required tool is missing.
+- **Run** `python scripts/apply_fix.py <audit.json> [--apply]` — without `--apply`, prints unified diffs only. With `--apply`, rewrites files in place: workflow `uses:` lines are bumped to the recommended ref preserving the original pin style (tag vs full SHA), and local `action.yml` `runs.using: node20` becomes `node24`. Exits non-zero if any finding was skipped (so CI can gate on a clean run).
+- **See** `scripts/audit.py` only when an unusual workflow shape needs custom classification — most users just run it.
+
+## References
+
+- [references/workflow-author.md](references/workflow-author.md) — perspective for repos that consume actions: bumping `uses:` versions, handling SHA pins, common-action migration table, dependabot config.
+- [references/action-author.md](references/action-author.md) — perspective for repos that publish actions: editing `runs.using`, Node 24 platform/runtime caveats (macOS, ARM32), release/test checklist.
+- [references/edge-cases.md](references/edge-cases.md) — composite actions, Docker actions, local actions, reusable workflows, archived/abandoned actions, the early-test and stay-on-Node-20 escape flags.
+
+## Conventions
+
+- Audit before fix; `--apply` is opt-in. Never rewrite without first showing diffs.
+- Preserve the existing pin style: tag-major (`@v4`) stays tag-major, full SHA stays full SHA, branch stays branch.
+- Never bump a major version silently — when the recommended Node 24 release crosses a major, surface the upstream release notes URL in the audit table so a human can review breaking changes before approving.
+- Don't touch third-party actions classed `node20-stuck`. Flag them and stop. The fix is upstream, not in the consuming repo.
+- Don't autocommit, push, or open PRs. Edits land locally for human review.
+- Skip Docker (`runs.using: docker`) actions — they don't run the runner-internal Node.
+- Treat `setup-node`'s `node-version` input as out of scope — that's the workflow's chosen Node, not the runner's.
+
+## Evaluation scenarios
+
+1. **Workflow audit, fully on Node 20.** Prompt: "Check if our workflows need updating for the Node 20 deprecation." Expected: skill triggers, runs `audit.py .`, reports a table classifying every `uses:` line, recommends Node 24 versions where they exist upstream.
+2. **Local action.yml on `node20`.** Prompt: "Migrate this action.yml off Node 20." Expected: skill detects the local `runs.using: node20`, dry-runs `apply_fix.py` showing the `node24` rewrite, applies after confirmation.
+3. **Decline irrelevant prompt.** Prompt: "Bump the Node version in `setup-node` to 22 in our build workflow." Expected: skill recognises this as a workflow-Node concern unrelated to the runner-internal Node deprecation, and either declines or explicitly notes the distinction before acting.

--- a/.claude/skills/gh-actions-node24-migration/references/action-author.md
+++ b/.claude/skills/gh-actions-node24-migration/references/action-author.md
@@ -1,0 +1,77 @@
+# Action author guide
+
+Use this when the repo *publishes* a JavaScript GitHub Action (i.e., it has an `action.yml` or `action.yaml` whose `runs.using` is `node20`). The job is to ship a release whose `action.yml` declares `node24`, without breaking consumers.
+
+## Contents
+
+- The single required edit
+- Verifying the action runs on Node 24
+- Platform and runtime caveats with Node 24
+- Release checklist
+- What to do if dependencies block the bump
+
+## The single required edit
+
+```diff
+ runs:
+-  using: node20
++  using: node24
+   main: dist/index.js
+```
+
+That's it. The runner reads `using:` and selects the corresponding bundled Node binary. `apply_fix.py` performs this exact rewrite for any local `action.yml` the audit classifies as `local-node20`.
+
+If the action also has a `pre:` or `post:` script, those run under the same Node version — no separate change needed.
+
+## Verifying the action runs on Node 24
+
+Two checks before tagging the release:
+
+1. **Local sanity.** Run the action's bundled script under a Node 24 binary:
+
+   ```sh
+   nvm install 24 && nvm use 24
+   node dist/index.js
+   ```
+
+   The action should execute its happy path without import or syntax errors. Most failures here are about dropped Node APIs — the migration guide at `https://nodejs.org/en/blog/announcements/v24-release-announce` lists what changed since Node 20.
+
+2. **End-to-end on a runner.** Push a branch with `runs.using: node24` and a workflow that consumes the action via `uses: <owner>/<repo>@<branch>`. Watch the run log. Look for warnings about deprecated APIs in addition to outright failures.
+
+## Platform and runtime caveats with Node 24
+
+Node 24 is stricter about platforms than Node 20. From the GitHub announcement:
+
+- **macOS 13.4 and earlier** — not supported. Self-hosted runners on older macOS must upgrade.
+- **ARM32** — dropped. Self-hosted runners on 32-bit ARM cannot run Node 24 actions. (GitHub-hosted runners are unaffected.)
+
+Action code itself rarely needs to care about either, but call this out in the release notes so consumers running self-hosted on those platforms know.
+
+Other behaviour changes worth scanning the action source for:
+
+- `node:fs` — promise-based methods are now the documented default; sync APIs in hot paths emit warnings.
+- `node:url` — `url.parse` is fully deprecated; use `new URL(...)`.
+- `process.binding(...)` — removed.
+- `Buffer()` constructor — emits an error; use `Buffer.alloc` / `Buffer.from`.
+
+If `package.json` has an `engines.node` field, bump it to `>=24` in the same release.
+
+## Release checklist
+
+1. Edit `action.yml`: `runs.using: node20` → `node24`.
+2. Bump `engines.node` in `package.json` (if present).
+3. Rebuild the bundled `dist/index.js` (e.g. `npm run build` or `ncc build src/index.ts`).
+4. Update `README.md` to note the Node 24 requirement.
+5. Open a PR titled "Migrate to Node 24 runtime".
+6. Smoke-test on a runner via a workflow that pins to the PR's SHA.
+7. Tag a new **major** release. Bumping the runtime is a breaking change for self-hosted consumers on dropped platforms — do not ship it as a minor bump.
+8. Update the moving major tag (e.g. `v5`) to point at the new release once the changelog is reviewed.
+9. Mention the change prominently in release notes — consumers will read these to decide whether to bump.
+
+## What to do if dependencies block the bump
+
+If a runtime dependency does not yet support Node 24:
+
+- Replace the dependency. Most popular npm packages already ship Node 24 support; if one does not, an alternative usually does.
+- If replacement is not feasible, ship an interim release that still declares `node20` and document the blocker in an issue. Consumers can use `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to smoke-test against Node 24 even on the old declaration, which gives early signal.
+- Keep the action published as Node 20 until the dependency lands. The runner-side `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` flag is a consumer-side escape hatch that works only until Node 20 is removed entirely — it is not a substitute for migrating the action.

--- a/.claude/skills/gh-actions-node24-migration/references/edge-cases.md
+++ b/.claude/skills/gh-actions-node24-migration/references/edge-cases.md
@@ -1,0 +1,66 @@
+# Edge cases
+
+Cases the audit and apply scripts intentionally hand back to a human reviewer rather than auto-fix.
+
+## Contents
+
+- Composite actions
+- Docker actions
+- Local action references
+- Reusable workflows
+- Archived or abandoned actions
+- The two escape flags
+- Marketplace actions hosted under user accounts
+- Monorepos with sub-path actions
+- Self-hosted runners
+
+## Composite actions
+
+A composite action declares `runs.using: composite` and orchestrates other steps; it does not run on Node itself. The audit classifies these as `composite` and recommends the latest release tag (if any) but does not infer a Node version. The Node concern lives one level deeper: the composite's own `steps[].uses:` references are what eventually run on Node 20 or Node 24.
+
+To audit a composite's internals, run the audit against a checkout of the composite's repo. The script descends into nested `action.yml` files automatically — what it does not do is fetch the composite's source over the network and recurse into it. That is intentional: latency would balloon, and a single composite can transitively reference dozens of upstream actions.
+
+## Docker actions
+
+`runs.using: docker` is unaffected — these execute the container's entrypoint, not the runner's bundled Node. The audit classifies them `docker` and skips them. Nothing further is needed.
+
+## Local action references
+
+A workflow line like `uses: ./local-action` resolves to an `action.yml` inside the same repo. The audit records the workflow line as `local-action` (so the reviewer sees it) and separately classifies the local `action.yml` itself as `local-node20`, `local-node24`, `composite`, or `docker`. The fix lands on the `action.yml`, not the workflow line.
+
+## Reusable workflows
+
+A line like `uses: org/repo/.github/workflows/build.yml@ref` consumes a *workflow*, not an action. Workflow YAML has no `runs.using`; the deprecation does not apply at this layer. The audit classifies these as `reusable-workflow` and skips them. Update the actions *inside* the reusable workflow at its source repo, not at the consumer.
+
+## Archived or abandoned actions
+
+If `gh api` returns 404 or the latest release still declares `node20`, the audit classifies the action as `unresolved` or `node20-stuck`. There is no auto-fix. Choices:
+
+1. Find a maintained alternative.
+2. Fork the action, change `runs.using: node20` to `node24` in the fork, smoke-test under `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`, and pin to the fork's SHA.
+3. Strip the action from the workflow if its work can be replaced by a `run:` step.
+
+Document the choice in the PR — abandoned-action escapes have a habit of becoming permanent.
+
+## The two escape flags
+
+`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` — set in a workflow's `env:` block. Forces every JavaScript action in that run to execute on Node 24, regardless of its declared `runs.using`. Use to smoke-test a workflow before bumping refs. Safe to leave on indefinitely; the flag becomes a no-op once Node 24 is the default.
+
+`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` — set on the runner (env, not workflow). Allows a Node 20 action to keep running after the runner default flips. Treat as a temporary unblock, not a fix. Stops working entirely once Node 20 is removed from the runner image. Skill scripts never write either flag — surfacing them is a human decision.
+
+## Marketplace actions hosted under user accounts
+
+Actions live at any `<owner>/<repo>` slug — they are not all under organisations like `actions/`. The audit treats every external slug identically: hit `gh api repos/<owner>/<repo>/contents/action.yml`, read `runs.using`, fetch `releases/latest`, classify. No special handling is needed.
+
+## Monorepos with sub-path actions
+
+Some repos publish multiple actions, each at a sub-path: `uses: org/repo/path/to/action@v3`. The audit splits the slug correctly (`slug=org/repo`, `sub_path=path/to/action`) and fetches `<sub_path>/action.yml`. Apply preserves the sub-path on rewrite.
+
+## Self-hosted runners
+
+The deprecation affects the Node binary that ships *with* the runner, not the OS-level Node. Self-hosted runners follow the same timeline as GitHub-hosted ones once they upgrade `actions/runner` past v2.328.0. Two extra concerns for self-hosted:
+
+- **macOS 13.4 or earlier** — Node 24 will not run; upgrade the host OS or the runner falls back to (and eventually loses) Node 20.
+- **ARM32** — Node 24 has no ARM32 build; these runners cannot execute Node 24 actions at all.
+
+The audit script does not detect runner OS or architecture. Read `runs-on:` in the workflow to spot self-hosted labels (`self-hosted`, custom labels) and verify the host fleet manually.

--- a/.claude/skills/gh-actions-node24-migration/references/workflow-author.md
+++ b/.claude/skills/gh-actions-node24-migration/references/workflow-author.md
@@ -1,0 +1,100 @@
+# Workflow author guide
+
+Use this when the repo *consumes* GitHub Actions but does not publish any. The job is to bump `uses:` references in `.github/workflows/*.yml` so every action lands on a release whose `action.yml` declares Node 24.
+
+## Contents
+
+- The mental model
+- Common-action migration table
+- SHA-pinned actions
+- Dependabot keeps it evergreen
+- Verifying with the early-test flag
+- When the upstream has no Node 24 release yet
+
+## The mental model
+
+A workflow line like `uses: actions/checkout@v4` resolves at runtime to the `action.yml` published at the `v4` tag. That file declares `runs.using: node20` today. The fix is to pin to a release whose `action.yml` declares `runs.using: node24`. The audit script does this lookup automatically. The apply script rewrites the `@<ref>` portion in place.
+
+There is nothing to change in `runs:` blocks of workflow files (workflow YAML has no `runs.using`). The only edit on the consumer side is the `@<ref>` after each action slug.
+
+## Common-action migration table
+
+These are the action families the audit will most often touch. Don't bake the right-hand column into anything — let the audit script discover the current Node 24 release at run time. The list is here only so a reviewer recognises which actions matter.
+
+| Action family                              | Today's typical Node 20 ref | Where Node 24 lands     |
+|--------------------------------------------|-----------------------------|-------------------------|
+| `actions/checkout`                         | `@v4`                       | `@v5` major or later    |
+| `actions/setup-node`                       | `@v4`                       | next major              |
+| `actions/setup-go`                         | `@v5`                       | next major              |
+| `actions/setup-python`                     | `@v5`                       | next major              |
+| `actions/setup-java`                       | `@v4`                       | next major              |
+| `actions/cache`                            | `@v4`                       | next major              |
+| `actions/upload-artifact`                  | `@v4`                       | next major              |
+| `actions/download-artifact`                | `@v4`                       | next major              |
+| `actions/configure-pages`                  | `@v5`                       | next major              |
+| `actions/upload-pages-artifact`            | `@v3`                       | next major              |
+| `actions/deploy-pages`                     | `@v4`                       | next major              |
+| `actions/labeler`                          | `@v5`                       | next major              |
+| `goreleaser/goreleaser-action`             | `@v6`                       | next major              |
+| `golangci/golangci-lint-action`            | `@v7` / `@v8`               | already shipping Node 24 in newer majors |
+| `docker/setup-buildx-action`               | `@v3`                       | next major              |
+| `docker/login-action`                      | `@v3`                       | next major              |
+| `docker/build-push-action`                 | `@v6`                       | next major              |
+
+A new major often crosses other breaking changes (changed default inputs, dropped flags). Before approving a bump that crosses a major, read the upstream release notes at `https://github.com/<slug>/releases`. The audit's `notes` column links to those when a major-version bump is detected.
+
+## SHA-pinned actions
+
+Many security-conscious repos pin to a 40-character commit SHA, not a tag, e.g.:
+
+```yaml
+uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+```
+
+The audit detects SHA pins (`pin_style: sha`) and the apply script preserves the style: it resolves the recommended tag back to a SHA via `gh api repos/<slug>/commits/<tag>` and writes the SHA, leaving the trailing `# vX.Y.Z` comment intact. Update the comment manually in the same edit (the apply script does not touch comments — it only edits the `@<ref>` portion of the line).
+
+If a SHA pin has no trailing comment, add one in the same PR. A bare 40-character SHA is unreviewable in a diff.
+
+## Dependabot keeps it evergreen
+
+Once the migration is done, add or update `.github/dependabot.yml` to keep actions current:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+```
+
+This is a one-time setup that means future Node bumps land as PRs without another audit run.
+
+## Verifying with the early-test flag
+
+Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in a workflow's `env:` block to force every JavaScript action in that run to execute on Node 24, even if its `action.yml` still declares `node20`. Use this to smoke-test that workflows still pass before swapping refs:
+
+```yaml
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "running on Node 24 even though checkout@v4 declares node20"
+```
+
+If the workflow passes with this flag, the bump to a Node 24 release is mechanical. If it fails, the failure is the action's, not the workflow's — file an upstream issue.
+
+## When the upstream has no Node 24 release yet
+
+The audit classifies these as `node20-stuck`. Options, ranked:
+
+1. **Wait.** Most popular actions will ship a Node 24 release before the runner default flips. Watch the upstream repo or rely on Dependabot.
+2. **Fork and patch** if the action is critical and unmaintained. Change `runs.using: node20` to `node24` in the fork, smoke-test with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`, then pin the workflow to the fork's SHA.
+3. **Replace.** Many actions have actively-maintained alternatives. The audit's `notes` column does not suggest replacements — that judgment is left to the reviewer.
+4. **Last resort:** set `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` on the runner to keep executing the action on Node 20 past the cutover. This works only until Node 20 is fully removed and is not a long-term answer.

--- a/.claude/skills/gh-actions-node24-migration/scripts/apply_fix.py
+++ b/.claude/skills/gh-actions-node24-migration/scripts/apply_fix.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Apply Node 24 migration fixes from an audit.json produced by audit.py.
+
+Usage: python apply_fix.py <audit.json> [--apply] [--repo-root .]
+
+Default mode is dry-run: prints unified diffs of every fix it would make and
+writes nothing. Pass --apply to write the changes in place.
+
+Handles two finding kinds:
+  - workflow-uses, state=node20-fixable
+      Rewrites the `uses: <slug>@<ref>` line in the workflow file to the
+      recommended ref. If the original ref was a 40-char SHA, the recommended
+      tag is resolved to its SHA via `gh api`. Comments and indentation on the
+      line are preserved.
+  - local-action, state=local-node20
+      Rewrites `using: node20` to `using: node24` inside the action.yml's
+      `runs:` block. Comments and quoting are preserved.
+
+Findings in any other state are skipped with a warning.
+
+Exit codes:
+  0  every non-skipped finding was applied successfully (or dry-run finished cleanly)
+  1  a fix failed to apply, OR one or more findings were skipped (e.g. node20-stuck)
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SHA_RE = re.compile(r'^[0-9a-f]{40}$')
+
+USES_LINE_RE = re.compile(
+    r'^(?P<prefix>\s*-?\s*uses\s*:\s*)'
+    r'(?P<value>[^\s#\'"][^#]*?|\'[^\']*\'|"[^"]*")'
+    r'(?P<trailer>\s*(?:#.*)?)$'
+)
+
+
+def have_gh() -> bool:
+    return shutil.which("gh") is not None
+
+
+_TAG_SHA_CACHE: dict[tuple[str, str], str | None] = {}
+
+
+def resolve_tag_to_sha(slug: str, tag: str) -> str | None:
+    key = (slug, tag)
+    if key in _TAG_SHA_CACHE:
+        return _TAG_SHA_CACHE[key]
+    # Try as a tag ref (annotated tags resolve via /git/refs/tags/<tag>; lightweight
+    # tags resolve directly). Fall back to /commits/<tag> which works for both.
+    p = subprocess.run(
+        ["gh", "api", f"repos/{slug}/commits/{tag}", "-q", ".sha"],
+        capture_output=True,
+        text=True,
+    )
+    if p.returncode == 0:
+        sha = p.stdout.strip()
+        if SHA_RE.match(sha):
+            _TAG_SHA_CACHE[key] = sha
+            return sha
+    _TAG_SHA_CACHE[key] = None
+    return None
+
+
+def strip_quotes(value: str) -> tuple[str, str]:
+    """Return (inner, quote_char). quote_char is '' if unquoted."""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1], value[0]
+    return value, ""
+
+
+def rewrite_uses_value(
+    original_value: str,
+    new_ref: str,
+) -> str:
+    """Rewrite the @ref portion of a uses: value, preserving any quoting."""
+    inner, quote = strip_quotes(original_value)
+    if "@" not in inner:
+        return original_value
+    path, _, _old_ref = inner.partition("@")
+    new_inner = f"{path}@{new_ref}"
+    return f"{quote}{new_inner}{quote}"
+
+
+def apply_workflow_fix(
+    file_text: str,
+    line_no: int,
+    expected_slug: str,
+    new_ref: str,
+) -> tuple[str, str]:
+    """Return (new_text, replaced_line) or raise ValueError if the line doesn't
+    match the expected pattern."""
+    lines = file_text.splitlines(keepends=True)
+    if line_no < 1 or line_no > len(lines):
+        raise ValueError(f"line {line_no} out of range (file has {len(lines)} lines)")
+    raw = lines[line_no - 1]
+    # Preserve the original line ending.
+    eol = ""
+    body = raw
+    if body.endswith("\r\n"):
+        eol, body = "\r\n", body[:-2]
+    elif body.endswith("\n"):
+        eol, body = "\n", body[:-1]
+    m = USES_LINE_RE.match(body)
+    if not m:
+        raise ValueError(f"line {line_no} does not look like a uses: line: {body!r}")
+    inner, _ = strip_quotes(m.group("value"))
+    path, _, _ = inner.partition("@")
+    if not path.startswith(expected_slug):
+        raise ValueError(
+            f"line {line_no} slug {path!r} does not match expected {expected_slug!r}"
+        )
+    new_value = rewrite_uses_value(m.group("value"), new_ref)
+    new_line = f"{m.group('prefix')}{new_value}{m.group('trailer')}{eol}"
+    lines[line_no - 1] = new_line
+    return "".join(lines), new_line.rstrip("\r\n")
+
+
+USING_LINE_RE = re.compile(
+    r'^(?P<prefix>\s+using\s*:\s*)'
+    r'(?P<quote>[\'"]?)node20(?P=quote)'
+    r'(?P<trailer>\s*(?:#.*)?)$'
+)
+
+
+def apply_local_action_fix(file_text: str) -> tuple[str, int]:
+    """Rewrite `using: node20` -> `using: node24` inside the runs: block.
+    Returns (new_text, lines_changed)."""
+    lines = file_text.splitlines(keepends=True)
+    runs_idx = None
+    runs_indent = -1
+    for i, line in enumerate(lines):
+        if re.match(r'^(\s*)runs\s*:\s*(?:#.*)?$', line):
+            runs_idx = i
+            runs_indent = len(re.match(r'^(\s*)', line).group(1))
+            break
+    if runs_idx is None:
+        raise ValueError("no `runs:` block found in action.yml")
+    changed = 0
+    for j in range(runs_idx + 1, len(lines)):
+        body = lines[j].rstrip("\r\n")
+        eol = lines[j][len(body):]
+        if body.strip() == "":
+            continue
+        # End of the runs: block: same-or-shallower indent on a non-empty line.
+        leading = len(re.match(r'^(\s*)', body).group(1))
+        if leading <= runs_indent and body.strip() and not body.startswith(" " * (runs_indent + 1)):
+            break
+        m = USING_LINE_RE.match(body)
+        if m:
+            new_body = f"{m.group('prefix')}{m.group('quote')}node24{m.group('quote')}{m.group('trailer')}"
+            lines[j] = new_body + eol
+            changed += 1
+    if changed == 0:
+        raise ValueError("no `using: node20` found inside runs: block")
+    return "".join(lines), changed
+
+
+def diff_text(path: str, before: str, after: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+        )
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("audit_json", type=Path, help="audit.json from audit.py")
+    ap.add_argument("--apply", action="store_true", help="Write changes (default: dry-run, prints diffs)")
+    ap.add_argument("--repo-root", type=Path, default=Path("."), help="Repo root for resolving file paths")
+    args = ap.parse_args()
+
+    if not args.audit_json.exists():
+        print(f"ERROR: {args.audit_json} not found", file=sys.stderr)
+        return 1
+
+    findings = json.loads(args.audit_json.read_text(encoding="utf-8"))
+    repo_root = args.repo_root.resolve()
+
+    applied = 0
+    skipped = 0
+    failed = 0
+
+    # Group workflow-uses findings by file so we apply all line edits to one buffer
+    # before writing — avoids stale line numbers if multiple uses: lines change.
+    by_file: dict[Path, list[dict]] = {}
+    local_actions: list[dict] = []
+    other_findings: list[dict] = []
+    for f in findings:
+        if f.get("kind") == "workflow-uses" and f.get("state") == "node20-fixable":
+            by_file.setdefault(repo_root / f["file"], []).append(f)
+        elif f.get("kind") == "local-action" and f.get("state") == "local-node20":
+            local_actions.append(f)
+        else:
+            other_findings.append(f)
+
+    for f in other_findings:
+        state = f.get("state", "")
+        if state in {"node24", "local-node24", "docker", "reusable-workflow", "local-action"}:
+            continue  # nothing to do, not counted as skipped
+        skipped += 1
+        print(
+            f"SKIP  {f.get('file')}:{f.get('line') or '-'}  "
+            f"{f.get('slug') or f.get('raw')}  state={state}  notes={f.get('notes', '')}",
+            file=sys.stderr,
+        )
+
+    # Workflow fixes
+    for path, items in by_file.items():
+        if not path.exists():
+            print(f"ERROR: {path} not found", file=sys.stderr)
+            failed += 1
+            continue
+        before = path.read_text(encoding="utf-8")
+        text = before
+        # Apply highest line numbers first so earlier line edits don't shift later ones.
+        items_sorted = sorted(items, key=lambda x: x["line"], reverse=True)
+        per_file_applied = 0
+        for f in items_sorted:
+            new_ref = f.get("recommended_ref", "")
+            if not new_ref:
+                print(f"ERROR: {f['file']}:{f['line']} no recommended_ref", file=sys.stderr)
+                failed += 1
+                continue
+            if f.get("pin_style") == "sha":
+                if not have_gh():
+                    print(
+                        f"ERROR: {f['file']}:{f['line']} pin_style=sha but `gh` not installed; "
+                        "cannot resolve recommended tag to SHA",
+                        file=sys.stderr,
+                    )
+                    failed += 1
+                    continue
+                sha = resolve_tag_to_sha(f["slug"], new_ref)
+                if not sha:
+                    print(
+                        f"ERROR: {f['file']}:{f['line']} could not resolve {f['slug']}@{new_ref} to SHA",
+                        file=sys.stderr,
+                    )
+                    failed += 1
+                    continue
+                new_ref_for_line = sha
+            else:
+                new_ref_for_line = new_ref
+            try:
+                text, _ = apply_workflow_fix(text, f["line"], f["slug"], new_ref_for_line)
+                per_file_applied += 1
+            except ValueError as exc:
+                print(f"ERROR: {f['file']}:{f['line']} {exc}", file=sys.stderr)
+                failed += 1
+
+        if per_file_applied == 0 or text == before:
+            continue
+
+        diff = diff_text(str(path.relative_to(repo_root)), before, text)
+        print(diff, end="" if diff.endswith("\n") else "\n")
+        if args.apply:
+            path.write_text(text, encoding="utf-8")
+        applied += per_file_applied
+
+    # Local action.yml fixes
+    for f in local_actions:
+        path = repo_root / f["file"]
+        if not path.exists():
+            print(f"ERROR: {path} not found", file=sys.stderr)
+            failed += 1
+            continue
+        before = path.read_text(encoding="utf-8")
+        try:
+            text, changed = apply_local_action_fix(before)
+        except ValueError as exc:
+            print(f"ERROR: {f['file']} {exc}", file=sys.stderr)
+            failed += 1
+            continue
+        if text == before:
+            continue
+        diff = diff_text(str(path.relative_to(repo_root)), before, text)
+        print(diff, end="" if diff.endswith("\n") else "\n")
+        if args.apply:
+            path.write_text(text, encoding="utf-8")
+        applied += changed
+
+    mode = "applied" if args.apply else "would apply"
+    print(
+        f"\n{mode}: {applied}  skipped: {skipped}  failed: {failed}",
+        file=sys.stderr,
+    )
+    if failed:
+        return 1
+    if skipped:
+        # Skipped findings are surfaced for human attention — exit non-zero so CI can gate.
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/gh-actions-node24-migration/scripts/audit.py
+++ b/.claude/skills/gh-actions-node24-migration/scripts/audit.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Audit GitHub Actions workflows and action.yml files for the Node 20 deprecation.
+
+Usage: python audit.py <repo-root> [--out audit.json] [--no-network]
+
+Walks <repo-root> for:
+  .github/workflows/*.yml, *.yaml         -> every `uses:` line
+  action.yml, action.yaml, **/action.yml  -> the `runs.using` field
+
+For each external `uses: <slug>@<ref>`, calls `gh api` to fetch the action.yml at
+that ref, reads runs.using, and (if node20) discovers the latest release on
+Node 24 if one exists.
+
+Emits a markdown table to stdout and structured findings to audit.json.
+
+Requires: gh CLI, authenticated. Pure stdlib otherwise.
+
+Exit codes:
+  0  audit complete (regardless of findings)
+  1  fatal (gh missing, repo path not a directory, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+USES_RE = re.compile(
+    r'^(?P<prefix>\s*-?\s*)uses\s*:\s*'
+    r'(?P<value>[^\s#\'"][^#]*?|\'[^\']*\'|"[^"]*")'
+    r'(?:\s+#.*)?\s*$'
+)
+USING_RE = re.compile(
+    r'^\s+using\s*:\s*[\'"]?(?P<val>[A-Za-z0-9_.-]+)[\'"]?\s*(?:#.*)?$',
+    re.M,
+)
+SHA_RE = re.compile(r'^[0-9a-f]{40}$')
+
+NODE20 = "node20"
+NODE24 = "node24"
+
+
+@dataclass
+class Finding:
+    file: str
+    line: int
+    kind: str  # "workflow-uses" | "local-action"
+    raw: str
+    slug: str = ""
+    sub_path: str = ""
+    ref: str = ""
+    pin_style: str = ""  # tag | sha | branch | unknown
+    state: str = ""  # node24 | node20-fixable | node20-stuck | local-node20 |
+                     # local-node24 | composite | docker | reusable-workflow |
+                     # local-action | unresolved | skipped
+    current_node: str = ""
+    recommended_ref: str = ""
+    recommended_node: str = ""
+    notes: str = ""
+
+
+# ---------------------------------------------------------------------------
+# gh api helpers
+# ---------------------------------------------------------------------------
+
+def have_gh() -> bool:
+    return shutil.which("gh") is not None
+
+
+_FILE_CACHE: dict[tuple[str, str, str], str | None] = {}
+
+
+def gh_api(path: str) -> tuple[int, str, str]:
+    p = subprocess.run(
+        ["gh", "api", path],
+        capture_output=True,
+        text=True,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def fetch_action_yml(owner: str, repo: str, sub_path: str, ref: str) -> str | None:
+    """Fetch action.yml or action.yaml from a repo at a specific ref. Cached."""
+    key = (f"{owner}/{repo}", sub_path, ref)
+    if key in _FILE_CACHE:
+        return _FILE_CACHE[key]
+    sub_path = sub_path.strip("/")
+    for fname in ("action.yml", "action.yaml"):
+        path_part = f"{sub_path}/{fname}" if sub_path else fname
+        api_path = f"repos/{owner}/{repo}/contents/{path_part}"
+        if ref:
+            api_path += f"?ref={ref}"
+        rc, out, _ = gh_api(api_path)
+        if rc != 0:
+            continue
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and data.get("encoding") == "base64":
+            try:
+                content = base64.b64decode(data["content"]).decode(
+                    "utf-8", errors="replace"
+                )
+                _FILE_CACHE[key] = content
+                return content
+            except (KeyError, ValueError):
+                continue
+    _FILE_CACHE[key] = None
+    return None
+
+
+_LATEST_CACHE: dict[str, str | None] = {}
+
+
+def fetch_latest_release_tag(owner: str, repo: str) -> str | None:
+    key = f"{owner}/{repo}"
+    if key in _LATEST_CACHE:
+        return _LATEST_CACHE[key]
+    rc, out, _ = gh_api(f"repos/{owner}/{repo}/releases/latest")
+    if rc != 0:
+        _LATEST_CACHE[key] = None
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        _LATEST_CACHE[key] = None
+        return None
+    tag = data.get("tag_name") if isinstance(data, dict) else None
+    _LATEST_CACHE[key] = tag
+    return tag
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def extract_using(text: str) -> str | None:
+    """Return the value of `using:` inside the first `runs:` block, or None."""
+    # Find a `runs:` line at column 0 (or any column) followed by indented block
+    runs_match = re.search(r'^(\s*)runs\s*:\s*(?:#.*)?$', text, re.M)
+    if not runs_match:
+        return None
+    runs_indent = len(runs_match.group(1))
+    start = runs_match.end()
+    # Slice until a sibling top-level key (same or shallower indent than runs_indent)
+    end = len(text)
+    for m in re.finditer(r'^(\s*)\S', text[start:], re.M):
+        if len(m.group(1)) <= runs_indent and start + m.start() != start:
+            end = start + m.start()
+            break
+    block = text[start:end]
+    using = USING_RE.search(block)
+    return using.group("val").lower() if using else None
+
+
+def strip_quotes(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1]
+    return value
+
+
+def classify_pin(ref: str) -> str:
+    if SHA_RE.match(ref):
+        return "sha"
+    if ref.startswith("v") and re.match(r'^v\d', ref):
+        return "tag"
+    if not ref:
+        return "unknown"
+    # Fallback: anything else (branch name, semver-without-v, exotic tag)
+    return "tag" if re.match(r'^[\w.\-]+$', ref) else "unknown"
+
+
+def split_uses(value: str) -> tuple[str, str, str, str]:
+    """Return (kind, slug, sub_path, ref).
+
+    kind is one of: 'external', 'local', 'docker', 'reusable-workflow', 'invalid'.
+    """
+    raw = strip_quotes(value)
+    if raw.startswith("docker://"):
+        return "docker", "", "", raw[len("docker://"):]
+    if raw.startswith("./") or raw.startswith("../"):
+        return "local", "", raw, ""
+    if "@" not in raw:
+        # Reusable workflow `uses: org/repo/.github/workflows/x.yml@ref` always has @.
+        # Anything else without @ is unusual / invalid.
+        return "invalid", "", "", raw
+    path, _, ref = raw.partition("@")
+    parts = path.split("/")
+    if len(parts) < 2:
+        return "invalid", "", "", raw
+    owner, repo = parts[0], parts[1]
+    sub = "/".join(parts[2:])
+    slug = f"{owner}/{repo}"
+    if sub.endswith(".yml") or sub.endswith(".yaml"):
+        # Looks like a reusable workflow file ref.
+        if "/.github/workflows/" in f"/{sub}":
+            return "reusable-workflow", slug, sub, ref
+    return "external", slug, sub, ref
+
+
+# ---------------------------------------------------------------------------
+# File walking
+# ---------------------------------------------------------------------------
+
+def find_workflow_files(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for wd in root.rglob(".github/workflows"):
+        if not wd.is_dir():
+            continue
+        for p in sorted(wd.iterdir()):
+            if p.is_file() and p.suffix.lower() in {".yml", ".yaml"}:
+                out.append(p)
+    return out
+
+
+def find_action_files(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for name in ("action.yml", "action.yaml"):
+        for p in root.rglob(name):
+            # Skip anything inside node_modules, .git, vendor, etc.
+            parts = set(p.parts)
+            if {".git", "node_modules", "vendor", "dist"} & parts:
+                continue
+            out.append(p)
+    return sorted(set(out))
+
+
+def iter_uses_lines(path: Path) -> list[tuple[int, str]]:
+    """Yield (line_number, raw_value) for every `uses:` line in the file."""
+    out: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return out
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = USES_RE.match(line)
+        if m:
+            out.append((i, m.group("value")))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+def classify_external(
+    finding: Finding,
+    network: bool,
+) -> None:
+    if not network:
+        finding.state = "skipped"
+        finding.notes = "network disabled"
+        return
+    owner, _, repo = finding.slug.partition("/")
+    text = fetch_action_yml(owner, repo, finding.sub_path, finding.ref)
+    if text is None:
+        finding.state = "unresolved"
+        finding.notes = "action.yml not reachable at this ref"
+        return
+    using = extract_using(text)
+    if using is None:
+        finding.state = "unresolved"
+        finding.notes = "runs.using not found in action.yml"
+        return
+    finding.current_node = using
+    if using == "docker":
+        finding.state = "docker"
+        return
+    if using == "composite":
+        finding.state = "composite"
+        finding.notes = "composite action — its inner uses: refs decide effective Node"
+        # Best-effort recommendation: latest tag.
+        latest = fetch_latest_release_tag(owner, repo)
+        if latest and latest != finding.ref:
+            finding.recommended_ref = latest
+        return
+    if using == NODE24:
+        finding.state = "node24"
+        return
+    if using == NODE20:
+        latest = fetch_latest_release_tag(owner, repo)
+        if not latest:
+            finding.state = "node20-stuck"
+            finding.notes = "no published release found"
+            return
+        latest_text = fetch_action_yml(owner, repo, finding.sub_path, latest)
+        latest_using = extract_using(latest_text) if latest_text else None
+        if latest_using == NODE24:
+            finding.state = "node20-fixable"
+            finding.recommended_ref = latest
+            finding.recommended_node = NODE24
+        else:
+            finding.state = "node20-stuck"
+            finding.recommended_ref = latest or ""
+            finding.recommended_node = latest_using or ""
+            finding.notes = "latest release still not on Node 24"
+        return
+    # Older or unknown runtime (node12/node16/etc.)
+    finding.state = "node20-stuck" if using.startswith("node") else "unresolved"
+    finding.notes = f"unexpected runs.using: {using}"
+
+
+def classify_local_action(path: Path, repo_root: Path) -> Finding:
+    rel = str(path.relative_to(repo_root))
+    finding = Finding(
+        file=rel,
+        line=0,
+        kind="local-action",
+        raw=rel,
+    )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        finding.state = "unresolved"
+        finding.notes = "could not decode as UTF-8"
+        return finding
+    using = extract_using(text)
+    if using is None:
+        finding.state = "unresolved"
+        finding.notes = "runs.using not found"
+        return finding
+    finding.current_node = using
+    if using == NODE20:
+        finding.state = "local-node20"
+        finding.recommended_node = NODE24
+    elif using == NODE24:
+        finding.state = "local-node24"
+    elif using == "composite":
+        finding.state = "composite"
+    elif using == "docker":
+        finding.state = "docker"
+    else:
+        finding.state = "unresolved"
+        finding.notes = f"unexpected runs.using: {using}"
+    return finding
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+STATE_PRIORITY = {
+    "node20-fixable": 0,
+    "local-node20": 1,
+    "node20-stuck": 2,
+    "unresolved": 3,
+    "composite": 4,
+    "reusable-workflow": 5,
+    "local-action": 6,
+    "docker": 7,
+    "node24": 8,
+    "local-node24": 9,
+    "skipped": 10,
+}
+
+
+def render_markdown_table(findings: list[Finding]) -> str:
+    if not findings:
+        return "_No findings — repo has no GitHub Actions workflows or local actions._\n"
+    cols = (
+        "File",
+        "Line",
+        "Action",
+        "Ref",
+        "Pin",
+        "State",
+        "Current",
+        "Recommended ref",
+        "Notes",
+    )
+    rows = [cols, ("---",) * len(cols)]
+    for f in findings:
+        action = f.slug + (f"/{f.sub_path}" if f.sub_path else "") if f.slug else f.raw
+        rows.append((
+            f.file,
+            str(f.line) if f.line else "-",
+            action,
+            f.ref or "-",
+            f.pin_style or "-",
+            f.state or "-",
+            f.current_node or "-",
+            f.recommended_ref or "-",
+            f.notes or "",
+        ))
+    widths = [max(len(str(r[i])) for r in rows) for i in range(len(cols))]
+    out_lines = []
+    for r in rows:
+        out_lines.append(
+            "| " + " | ".join(str(r[i]).ljust(widths[i]) for i in range(len(cols))) + " |"
+        )
+    return "\n".join(out_lines) + "\n"
+
+
+def render_summary(findings: list[Finding]) -> str:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.state] = counts.get(f.state, 0) + 1
+    if not counts:
+        return ""
+    parts = [f"{counts[k]} {k}" for k in sorted(counts, key=lambda s: STATE_PRIORITY.get(s, 99))]
+    return "Summary: " + ", ".join(parts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("repo_root", type=Path, help="Path to the repo to audit")
+    ap.add_argument("--out", type=Path, default=Path("audit.json"), help="Path to write audit JSON")
+    ap.add_argument(
+        "--no-network",
+        action="store_true",
+        help="Skip gh api calls (smoke-test mode; states will be 'skipped' for external uses)",
+    )
+    args = ap.parse_args()
+
+    if not args.repo_root.is_dir():
+        print(f"ERROR: {args.repo_root} is not a directory", file=sys.stderr)
+        return 1
+
+    network = not args.no_network
+    if network and not have_gh():
+        print(
+            "ERROR: `gh` CLI not found on PATH. Install it (https://cli.github.com) or rerun with --no-network.",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings: list[Finding] = []
+
+    # 1. Workflow files
+    for wf in find_workflow_files(args.repo_root):
+        rel = str(wf.relative_to(args.repo_root))
+        for line, value in iter_uses_lines(wf):
+            kind, slug, sub, ref = split_uses(value)
+            f = Finding(
+                file=rel,
+                line=line,
+                kind="workflow-uses",
+                raw=strip_quotes(value),
+                slug=slug,
+                sub_path=sub,
+                ref=ref,
+                pin_style=classify_pin(ref) if ref else "unknown",
+            )
+            if kind == "docker":
+                f.state = "docker"
+            elif kind == "local":
+                f.state = "local-action"
+                f.notes = f"local action ref: {sub}"
+            elif kind == "reusable-workflow":
+                f.state = "reusable-workflow"
+                f.notes = "reusable workflow file (not affected by Node deprecation)"
+            elif kind == "invalid":
+                f.state = "unresolved"
+                f.notes = "could not parse as <slug>@<ref>"
+            else:
+                classify_external(f, network)
+            findings.append(f)
+
+    # 2. Local action.yml files
+    for ap_path in find_action_files(args.repo_root):
+        findings.append(classify_local_action(ap_path, args.repo_root))
+
+    findings.sort(key=lambda f: (STATE_PRIORITY.get(f.state, 99), f.file, f.line))
+
+    # Output
+    print(render_markdown_table(findings))
+    summary = render_summary(findings)
+    if summary:
+        print(summary)
+
+    args.out.write_text(
+        json.dumps([asdict(f) for f in findings], indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote {len(findings)} finding(s) to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/skill-authoring/SKILL.md
+++ b/.claude/skills/skill-authoring/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: skill-authoring
+description: Authors and reviews agent skills for this repo, enforcing progressive disclosure (metadata → instructions → resources), ≤500-line SKILL.md files, domain-split references, scripts over prose for deterministic work, and specific third-person descriptions. Use when creating a new skill, splitting an oversized SKILL.md, or reviewing an existing skill for structure.
+---
+
+# Skill Authoring
+
+This skill codifies the authoring discipline so every skill loads cheaply and triggers accurately.
+
+## Why progressive disclosure
+
+An agent skill is a folder with `SKILL.md` at its root. The agent loads content across three levels — each step costs
+more context, so keep lower levels lean.
+
+| Level           | When loaded                                       | Budget                     | Content                                 |
+|-----------------|---------------------------------------------------|----------------------------|-----------------------------------------|
+| 1. Metadata     | Always, at startup                                | ~100 tokens per skill      | `name` + `description` from frontmatter |
+| 2. Instructions | When the skill triggers                           | <5,000 tokens (≤500 lines) | `SKILL.md` body                         |
+| 3. Resources    | On demand, via explicit links or script execution | Effectively unlimited      | `references/`, `scripts/`, `assets/`    |
+
+Scripts are especially efficient: the source never enters context — only the **output** does.
+
+## Authoring a new skill
+
+1. **Copy the template.** Copy `templates/SKILL.md.tmpl` from this skill into your new skill's folder as `SKILL.md`,
+   then fill it in. Place the skill wherever skills live in the current repo (e.g. `skills/<your-skill>/`).
+2. **Write the description first.** Third person, include *what* the skill does AND *when* to use it.
+   See [templates/description-examples.md](templates/description-examples.md) for good vs bad examples.
+3. **Draft 3 evaluation scenarios before prose.** Capture concrete prompts the skill should handle (and ones it should
+   decline), alongside the expected behaviour. Real failures drive what you document — this keeps the skill lean.
+4. **Write the minimum SKILL.md needed to pass the evals.** Resist documenting edge cases you haven't seen fail.
+5. **Split early if content grows.** See [references/patterns.md](references/patterns.md) for the four split patterns.
+6. **Lint before committing.** **Run** the linter from this skill against your new skill directory — see the
+   Resources section below for the exact script path.
+7. **Walk the review checklist.** See [references/review-checklist.md](references/review-checklist.md).
+
+## Hard authoring rules
+
+- `SKILL.md` ≤ 500 lines. Target ≤ 200.
+- Description is third person, specific, includes what + when. Vague descriptions don't trigger.
+- References are one level deep — `SKILL.md` links to reference files, references do NOT link to further references.
+  Agents often preview links with `head -100` and miss content past that on chained links.
+- Reference files over ~100 lines start with a Contents / TOC block.
+- Name files by content (`references/finance.md`), not position (`docs/file2.md`).
+- Use forward slashes in paths — backslashes break on Unix.
+- Avoid time-sensitive wording (`"after August 2025..."`) in the main flow. Move legacy content into a collapsed "old
+  patterns" section.
+- Deterministic work belongs in `scripts/`, not Markdown.
+
+## Execution intent: be explicit
+
+When referencing a script, state whether the agent should **run** it or **read** it:
+
+- **Run** `python scripts/fetch_osm.py --bbox ...` — produces GeoJSON on stdout. (Agent executes.)
+- **See** `scripts/fetch_osm.py` for the Overpass query it issues. (Agent reads as reference.)
+
+Execution is almost always what you want — scripts are more reliable than generated code, cheaper in context, and
+consistent across runs.
+
+## When to split SKILL.md
+
+Three signals:
+
+1. **Length.** File is pushing 500 lines.
+2. **Mutually-exclusive contexts.** Two user tasks never need the same sections. Example: a Bo-Kaap question never needs
+   Camps Bay lore.
+3. **Code vs prose.** Long inline code blocks the agent will re-type anyway — move to `scripts/`.
+
+The four split patterns, with worked examples specific to this repo's skills, live
+in [references/patterns.md](references/patterns.md).
+
+## Folder layout
+
+```
+<skill-name>/
+├── SKILL.md          # Required
+├── references/       # Optional — loaded on demand via explicit link
+├── scripts/          # Optional — executed, source never loaded
+├── templates/        # Optional — starter files users copy
+└── assets/           # Optional — images, palettes, map files
+```
+
+## Review and maintenance
+
+- Before merging a new or edited skill: run the linter and walk the checklist.
+- If a reference file grows past ~100 lines, add a TOC.
+- If `SKILL.md` grows past ~300 lines, plan a split before it hits 500.
+- If a skill stops triggering when expected, tighten its description — add concrete keywords from real user prompts.
+
+## Resources
+
+- [references/patterns.md](references/patterns.md) — the four split patterns with repo-specific examples.
+- [references/review-checklist.md](references/review-checklist.md) — pre-merge checklist.
+- [templates/SKILL.md.tmpl](templates/SKILL.md.tmpl) — starter template to copy.
+- [templates/description-examples.md](templates/description-examples.md) — good vs bad description examples.
+- **Run** `python scripts/lint_skill.py <skill-dir>` — lints a skill directory for the rules above.

--- a/.claude/skills/skill-authoring/references/patterns.md
+++ b/.claude/skills/skill-authoring/references/patterns.md
@@ -1,0 +1,136 @@
+# Skill Split Patterns
+
+## Contents
+
+- Pattern 1: High-Level Guide with References
+- Pattern 2: Domain-Specific Organisation
+- Pattern 3: Conditional Detail
+- Pattern 4: Scripts Instead of Prose
+- Choosing a pattern
+- Combining patterns
+
+---
+
+## Pattern 1: High-Level Guide with References
+
+Keep `SKILL.md` as a lightweight overview and link out to deeper material. The agent loads additional files only when the specific feature is needed.
+
+```
+pdf-processing/
+├── SKILL.md         # Overview + quick start
+├── FORMS.md         # Form-filling guide
+├── REFERENCE.md     # Full API reference
+└── EXAMPLES.md      # Common patterns
+```
+
+In `SKILL.md`:
+
+```markdown
+## Advanced features
+
+**Form filling**: see FORMS.md
+**API reference**: see REFERENCE.md
+**Examples**: see EXAMPLES.md
+```
+
+**When to use:** the skill covers one cohesive domain but has distinct deep-dive features most users won't need.
+
+**Example:** a game skill's `SKILL.md` links out to `references/tilemap-loading.md`, `references/player-movement.md`, `references/npc-dialogue.md`, `references/camera.md`. A question about camera bounds pulls in `SKILL.md` + `camera.md` only.
+
+---
+
+## Pattern 2: Domain-Specific Organisation
+
+Split references by domain so the agent only pulls in the relevant slice.
+
+```
+bigquery-skill/
+├── SKILL.md
+└── reference/
+    ├── finance.md   # Revenue, ARR, billing
+    ├── sales.md     # Pipeline, opportunities
+    ├── product.md   # API usage, features
+    └── marketing.md # Attribution, campaigns
+```
+
+A question about sales pipeline reads `SKILL.md` + `reference/sales.md`. The other three files never enter context.
+
+**When to use:** the skill spans domains where one user's questions are irrelevant to another's.
+
+**Example:** a city-lore skill with one reference file per neighbourhood (`bo-kaap.md`, `sea-point.md`, `camps-bay.md`, …). Bo-Kaap content never loads for a Camps Bay question, and vice versa. The SKILL.md acts as a navigation map.
+
+---
+
+## Pattern 3: Conditional Detail
+
+Show the common path in `SKILL.md`; link out to rare-but-important paths.
+
+```markdown
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: see REDLINING.md
+**For OOXML internals**: see OOXML.md
+```
+
+**When to use:** there's a clear 80/20 split between the common path and rare edge cases. Keeping edge cases inline bloats every activation for the 80% who don't need them.
+
+**Example:** a tiled-map authoring skill's `SKILL.md` covers the happy path for adding a tile layer; `references/collision-authoring.md` covers the less common collision-shape authoring; `references/event-triggers.md` covers POI interaction objects.
+
+---
+
+## Pattern 4: Scripts Instead of Prose
+
+Deterministic logic belongs in a script, not in Markdown. The script's source never enters context — only its output does.
+
+```
+pdf-skill/
+├── SKILL.md
+└── scripts/
+    ├── analyze_form.py
+    ├── fill_form.py
+    └── validate.py
+```
+
+In `SKILL.md`, be explicit about execution intent:
+
+```markdown
+Run: `python scripts/analyze_form.py input.pdf > fields.json`
+```
+
+versus
+
+```markdown
+See `scripts/analyze_form.py` for the extraction algorithm.
+```
+
+The first tells the agent to execute. The second tells it to read as reference. **Execution is almost always what you want** — pre-made scripts are more reliable than generated code, cheaper in context, and consistent across runs.
+
+**When to use:** the work is deterministic (parsing, querying, projecting, validating). If a prompt would ask the agent to re-type the same code every time, it belongs in a script.
+
+**Example:** a map-data skill's `scripts/fetch_osm.py` issues an Overpass API query and emits GeoJSON. The agent runs it, consumes the output, never reads the script body.
+
+---
+
+## Choosing a pattern
+
+| Signal in the content | Pattern |
+|-----------------------|---------|
+| SKILL.md has distinct feature deep-dives | 1 |
+| Content splits cleanly by audience or sub-domain | 2 |
+| 80/20 happy path vs rare edge cases | 3 |
+| Same deterministic code re-typed across uses | 4 |
+
+---
+
+## Combining patterns
+
+A mature skill often uses all four at once:
+
+- `SKILL.md` is a thin overview (Pattern 1).
+- References are split by sub-domain (Pattern 2).
+- Rare edge cases are linked-out from each section (Pattern 3).
+- Deterministic steps live in `scripts/` with explicit "Run:" instructions (Pattern 4).
+
+A map-data skill is a natural candidate for all four once it grows — thin SKILL.md, references split by feature type (e.g. `overpass-queries.md`, `projection.md`), edge cases for unusual POI types linked out, and all fetch/convert work in scripts.

--- a/.claude/skills/skill-authoring/references/review-checklist.md
+++ b/.claude/skills/skill-authoring/references/review-checklist.md
@@ -1,0 +1,46 @@
+# Skill Review Checklist
+
+Walk this list before merging any new skill or edit. Lint runs first; the checklist catches things the linter can't.
+
+## Frontmatter
+
+- [ ] `name` present, lowercase-hyphenated, matches the folder name exactly.
+- [ ] `description` present, third person, ≤ 2 sentences.
+- [ ] Description includes **what** the skill does AND **when** to use it.
+- [ ] Description includes concrete keywords an agent can match on (tool names, formats, file types, domain terms) — not just vague categories.
+
+## SKILL.md body
+
+- [ ] `wc -l SKILL.md` ≤ 500. Target ≤ 200.
+- [ ] No time-sensitive wording in the main flow ("after August 2025", "until we migrate"). Move legacy content to a collapsed section.
+- [ ] All relative links use forward slashes.
+- [ ] All relative links stay within the skill folder (no `../` into other skills). Duplicate a short snippet if needed; let the other skill trigger separately for longer content.
+- [ ] Every script reference is explicit about intent — **Run** (execute) vs **See** (read as reference).
+
+## References
+
+- [ ] References are one level deep — SKILL.md links to them; references do NOT link to further reference files.
+- [ ] Reference files over ~100 lines open with a Contents / TOC block.
+- [ ] Filenames describe content (`collision-authoring.md`, `finance.md`), not position (`doc2.md`, `ref1.md`).
+
+## Scripts
+
+- [ ] Each script starts with a docstring or one-line comment stating its purpose.
+- [ ] SKILL.md shows the exact invocation (`python scripts/foo.py <args>`) and the expected output shape.
+- [ ] Scripts take inputs from args or stdin — no paths hardcoded to the author's machine.
+- [ ] Scripts exit with non-zero on failure; success is silent or produces the documented output.
+
+## Assets
+
+- [ ] Binary assets are small enough to ship in the repo (target ≤ 100 KB each).
+- [ ] Asset filenames describe content.
+
+## Evaluation
+
+- [ ] At least one concrete scenario (a real prompt + expected behaviour) exercises this skill's main path.
+- [ ] Scenarios were written **before** SKILL.md prose, or at minimum drove the prose content.
+
+## Lint
+
+- [ ] `python <path-to>/skill-authoring/scripts/lint_skill.py <path-to>/<skill>` exits 0.
+- [ ] Any warnings are either fixed or explicitly justified in the PR description.

--- a/.claude/skills/skill-authoring/scripts/lint_skill.py
+++ b/.claude/skills/skill-authoring/scripts/lint_skill.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Lint an agent skill directory against this repo's authoring rules.
+
+Usage: python lint_skill.py <skill-dir>
+
+Checks:
+- <skill-dir>/SKILL.md exists
+- Frontmatter has name (matches folder) and description
+- Description is <= 2 sentences, third person, mentions "when" to use
+- SKILL.md body <= 500 lines (warn at > 300)
+- Reference files > 100 lines have a Contents/TOC block near the top
+- SKILL.md relative links use forward slashes and stay inside the skill dir
+- Reference files do not link to further reference files (one-level rule)
+- Filenames are not positional (file1.md, doc2.md, ref3.md)
+- SKILL.md body has no time-sensitive wording ("after <year>", etc.)
+
+Exits 0 on clean run, 1 if any ERROR, prints WARNINGs either way.
+Templates (files ending with .tmpl) are skipped.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ERRORS: list[str] = []
+WARNINGS: list[str] = []
+
+
+def err(msg: str) -> None:
+    ERRORS.append(msg)
+
+
+def warn(msg: str) -> None:
+    WARNINGS.append(msg)
+
+
+FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
+
+
+def parse_frontmatter(text: str):
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None, text
+    fm_block = match.group(1)
+    body = text[match.end():]
+    meta: dict[str, str] = {}
+    current_key = None
+    for line in fm_block.splitlines():
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_-]*:\s", line) or line.endswith(":"):
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+            current_key = key.strip()
+        elif current_key and line.startswith(" "):
+            meta[current_key] = (meta[current_key] + " " + line.strip()).strip()
+    return meta, body
+
+
+SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+PERSON_WORDS = re.compile(r"\b(you|your|yours|we|our|ours|us|i|me|my)\b", re.I)
+WHEN_PHRASE = re.compile(r"\b(use when|used when|used to|used for|use for|use this when)\b", re.I)
+TIME_SENSITIVE = re.compile(r"\b(after|until|before)\s+(19|20)\d{2}\b", re.I)
+LINK_RE = re.compile(r"\]\(([^)]+)\)")
+POSITIONAL = re.compile(r"^(file|doc|page|ref|part|section)\d+\.(md|py|mjs|js|ts)$", re.I)
+
+
+def lint_skill_md(path: Path, skill_dir: Path) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        err(f"{path}: could not be decoded as UTF-8: {exc}")
+        return
+    meta, body = parse_frontmatter(text)
+
+    if meta is None:
+        err(f"{path}: missing YAML frontmatter")
+        return
+
+    expected_name = path.parent.name
+    name = meta.get("name", "").strip()
+    if not name:
+        err(f"{path}: frontmatter missing 'name'")
+    elif name != expected_name:
+        err(f"{path}: frontmatter name {name!r} does not match folder {expected_name!r}")
+
+    desc = meta.get("description", "").strip().strip('"').strip("'")
+    if not desc:
+        err(f"{path}: frontmatter missing 'description'")
+    else:
+        sentences = [s for s in SENTENCE_SPLIT.split(desc) if s.strip()]
+        if len(sentences) > 2:
+            warn(f"{path}: description is {len(sentences)} sentences (target <= 2)")
+        if PERSON_WORDS.search(desc):
+            warn(f"{path}: description appears to use first/second person; prefer third person")
+        if not WHEN_PHRASE.search(desc):
+            warn(f"{path}: description should include 'when' to use the skill (e.g. 'Use when ...')")
+
+    lines = body.splitlines()
+    n = len(lines)
+    if n > 500:
+        err(f"{path}: SKILL.md body is {n} lines (hard limit 500)")
+    elif n > 300:
+        warn(f"{path}: SKILL.md body is {n} lines (target <= 200, warn >= 300)")
+
+    if TIME_SENSITIVE.search(body):
+        warn(f"{path}: body contains time-sensitive wording; move to a legacy section")
+
+    skill_dir_resolved = skill_dir.resolve()
+    for m in LINK_RE.finditer(body):
+        link = m.group(1).strip()
+        if link.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        if "\\" in link:
+            err(f"{path}: link {link!r} uses backslashes; use forward slashes")
+        target = link.split("#", 1)[0]
+        if not target:
+            continue
+        if target.startswith("/"):
+            err(f"{path}: link {link!r} is absolute; use a relative path inside the skill directory")
+            continue
+        resolved = (path.parent / target).resolve()
+        try:
+            resolved.relative_to(skill_dir_resolved)
+        except ValueError:
+            err(f"{path}: link {link!r} escapes the skill directory")
+
+
+TOC_HEADING_RE = re.compile(r"^#{1,3}\s+(contents|table of contents|toc)\b", re.I | re.M)
+
+
+def lint_reference(path: Path) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        err(f"{path}: could not be decoded as UTF-8: {exc}")
+        return
+    lines = text.splitlines()
+    n = len(lines)
+
+    if n > 100:
+        head = "\n".join(lines[:40])
+        if not TOC_HEADING_RE.search(head):
+            warn(f"{path}: {n} lines without a TOC (add a Contents block for files over 100 lines)")
+
+    for m in LINK_RE.finditer(text):
+        link = m.group(1).strip()
+        if link.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        target = link.split("#", 1)[0]
+        if not target:
+            continue
+        if target.endswith(".md") and not target.startswith("../"):
+            warn(f"{path}: reference links to another file {link!r}; references should be one level deep")
+
+
+def lint_filenames(skill_dir: Path) -> None:
+    for p in skill_dir.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix == ".tmpl":
+            continue
+        if POSITIONAL.match(p.name):
+            err(f"{p}: positional filename; rename to describe content")
+
+
+def lint_directory(skill_dir: Path) -> None:
+    if not skill_dir.is_dir():
+        err(f"{skill_dir}: not a directory")
+        return
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        err(f"{skill_dir}: missing SKILL.md")
+        return
+
+    lint_skill_md(skill_md, skill_dir)
+    lint_filenames(skill_dir)
+
+    for ref_dir_name in ("references", "reference"):
+        ref_dir = skill_dir / ref_dir_name
+        if ref_dir.exists():
+            for p in sorted(ref_dir.rglob("*.md")):
+                lint_reference(p)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+
+    target = Path(sys.argv[1])
+    lint_directory(target)
+
+    for w in WARNINGS:
+        print(f"WARN  {w}")
+    for e in ERRORS:
+        print(f"ERROR {e}")
+
+    print(f"\n{len(ERRORS)} error(s), {len(WARNINGS)} warning(s)")
+    sys.exit(1 if ERRORS else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-authoring/templates/SKILL.md.tmpl
+++ b/.claude/skills/skill-authoring/templates/SKILL.md.tmpl
@@ -1,0 +1,46 @@
+---
+name: REPLACE-with-folder-name-lowercase-hyphenated
+description: REPLACE with one or two third-person sentences. Describe WHAT this skill does and WHEN to use it. Include concrete keywords the agent will match on (tool names, file types, domains). Example shape — "Fetches OpenStreetMap data for Cape Town's City Bowl and converts it to Phaser-ready tile coordinates. Use when generating the base map, adding a neighbourhood, or placing real-world POIs onto the tile grid."
+---
+
+# REPLACE with Skill Title
+
+REPLACE with a one-paragraph overview: what this skill lets the agent do, and why it's a skill (progressive disclosure benefit) rather than inline prose in a CLAUDE.md.
+
+## Quick start
+
+REPLACE with the happy-path workflow — the single most common thing a user will ask. Show commands inline. Keep it to 5–10 lines.
+
+## REPLACE with feature / section 2
+
+Cover the next most common path here. If any subsection has deep detail, link out instead of inlining:
+
+For REPLACE-topic, see [references/REPLACE-topic.md](references/REPLACE-topic.md).
+
+## Scripts
+
+List every script with exact invocation and expected output. Be explicit about execution intent.
+
+- **Run** `python scripts/REPLACE-script.py <args>` — REPLACE with what it does and what it emits.
+- **See** `scripts/REPLACE-script.py` — REPLACE (use only when the agent should read, not execute).
+
+## References
+
+One-line description per file. The agent uses these lines to decide whether to open a reference.
+
+- [references/REPLACE-topic-a.md](references/REPLACE-topic-a.md) — REPLACE with one-line description.
+- [references/REPLACE-topic-b.md](references/REPLACE-topic-b.md) — REPLACE with one-line description.
+
+## Conventions
+
+REPLACE with any hard rules this skill enforces — naming, layer structure, format requirements, palette constraints. Keep this section as a bulleted list of imperatives.
+
+<!--
+Author's checklist before committing (delete this comment block before merge):
+
+1. Replace every REPLACE-... placeholder.
+2. Draft 3 eval scenarios (real prompts + expected behaviour) FIRST, before writing prose.
+3. Keep this file ≤ 200 lines.
+4. Run: python <path-to>/skill-authoring/scripts/lint_skill.py .
+5. Walk <path-to>/skill-authoring/references/review-checklist.md.
+-->

--- a/.claude/skills/skill-authoring/templates/description-examples.md
+++ b/.claude/skills/skill-authoring/templates/description-examples.md
@@ -1,0 +1,60 @@
+# Descriptions: Good vs Bad
+
+The `description` is the **only** signal the agent uses to decide whether to trigger a skill. A vague description → skill never fires. A specific description with concrete keywords → skill fires at the right moment.
+
+## Rules
+
+1. **Third person.** "Authors skills..." not "You author skills...".
+2. **What + when.** Both must be present.
+3. **Concrete keywords.** Names of tools, formats, file types, domains the user is likely to mention.
+4. **≤ 2 sentences.**
+
+## Side-by-side examples
+
+### Too vague
+> Helps with documents.
+
+Never triggers reliably. "Documents" is too generic.
+
+### Better
+> Extracts text and tables from PDF files, fills forms, merges documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+
+Concrete keywords ("PDF", "forms", "extraction"); what + when both present.
+
+---
+
+### Too vague
+> Cape Town stuff.
+
+### Better
+> Reference material on Cape Town's City Bowl and Atlantic Seaboard neighbourhoods — real landmarks, history, culture, typical activity — used to inform NPC dialogue, quest design, building names, and atmosphere. Use when writing dialogue or quests, naming buildings, or choosing which POIs are interactive in a given area.
+
+---
+
+### Wrong person (second)
+> Use this skill when you want to add a Phaser scene.
+
+### Right (third)
+> Phaser 3 patterns for this game: scene lifecycle, Tiled map loading, player movement with arrow/WASD keys, camera follow, layer-based collision, NPC interaction, and dialogue. Use when wiring new game code, adding a scene, debugging movement or collision, or integrating a new interactive object type.
+
+---
+
+### Missing "when"
+> Defines the game's pixel-art conventions.
+
+### Complete
+> Defines the game's pixel-art conventions — 32×32 tile grid, 3/4 top-down perspective, palette, walk-cycle frame counts, building-facade construction — and guides authoring or commissioning new sprites. Use when adding a character, building, prop, or tileset art, or when reviewing art for consistency.
+
+---
+
+### Missing "what" (just categories)
+> For game evaluation tasks.
+
+### Complete
+> Evaluation scenarios that exercise the game end-to-end — walk-route coverage, collision correctness, POI trigger firing, visual consistency, dialogue flow. Use when adding a feature, before merging map or engine changes, or when building a new skill.
+
+## The trigger test
+
+Ask: "If the agent had 100 skills listed by description alone, and a user said `<realistic prompt>`, would it pick this one over the others?"
+
+If the answer isn't obvious, make the description more specific — usually by naming the tool, format, or domain term the user is most likely to say.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,10 +51,10 @@ jobs:
             fuzz_test: FuzzGenerateFeedID
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.26'
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload fuzz corpus
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: fuzz-corpus-${{ matrix.package }}-${{ matrix.fuzz_test }}
           path: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.4.0
       with:
         go-version: '1.26'
 
@@ -42,7 +42,7 @@ jobs:
         go test ./mcpserver -run=^$ -fuzz=FuzzParseURIParameters -fuzztime=1x
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9.2.0
       with:
         version: v2.9.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: stable
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7.2.1
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary

GitHub is [deprecating the Node 20 runtime on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The runner default flips to Node 24, then Node 20 is removed entirely. This PR ships three things together:

1. The **migration itself** — bumps every JavaScript action in our workflows to a release whose `action.yml` declares `runs.using: node24`.
2. A **`gh-actions-node24-migration` skill** that automated the migration and can be re-run against any repo.
3. A **`skill-authoring` meta-skill** — the authoring discipline + linter the migration skill was built against.

## Version bumps

| Action | Old | New | Major jumps |
|---|---|---|---|
| `actions/checkout` | `v4` | `v6.0.2` | 2 |
| `actions/setup-go` | `v5` | `v6.4.0` | 1 |
| `actions/upload-artifact` | `v4` | `v7.0.1` | 3 |
| `golangci/golangci-lint-action` | `v7` | `v9.2.0` | 2 |
| `goreleaser/goreleaser-action` | `v6` | `v7.2.1` | 1 |

Several cross multiple majors. Reviewer should skim each upstream changelog for breaking changes — CI on this PR exercises Go and lint paths; goreleaser only fires on tag push, so its v7 bump gets verified at the next release.

`ncruces/go-coverage-report@v0` is a composite action and stays on its moving `v0` tag — its upstream maintainer is responsible for the internal Node version bump.

## Skills

`.claude/skills/skill-authoring/` — meta-skill codifying progressive disclosure (metadata → instructions → resources), the ≤500-line `SKILL.md` cap, third-person specific descriptions, and "scripts over prose" for deterministic work. Includes `scripts/lint_skill.py` that every skill in this repo must pass.

`.claude/skills/gh-actions-node24-migration/` — the skill that performed this migration:

- `SKILL.md` — overview, quick start, classification table, conventions.
- `scripts/audit.py` — walks `.github/workflows/*.yml` and `**/action.yml`, calls `gh api` to read each action's `action.yml` at its pinned ref, then walks `releases/latest` to find the first Node 24-compatible tag. Emits a markdown table + `audit.json`.
- `scripts/apply_fix.py` — dry-run by default; `--apply` writes. Rewrites `uses:` `@<ref>` preserving pin style (resolves tag → SHA via `gh api` for SHA-pinned lines) and rewrites local `runs.using: node20` → `node24`.
- `references/{workflow-author,action-author,edge-cases}.md` — the 80% guides plus awkward-cases doc.

Lints clean (0 errors, 0 warnings) against the meta-skill's linter. Needs `gh` on PATH and authenticated.

## Test plan

- [ ] `Go` workflow passes on this PR (covers `actions/checkout`, `actions/setup-go`, `golangci/golangci-lint-action`)
- [ ] `Fuzz Testing` workflow can be dispatched manually and uploads artifacts (covers `actions/upload-artifact` v4 → v7 — verify artifact name uniqueness still holds with matrix names)
- [ ] `goreleaser` workflow dry-runs cleanly on the next tag (covers `goreleaser/goreleaser-action` v6 → v7)
- [ ] No deprecation warnings in workflow logs
- [ ] Skill smoke test post-merge: `python3 .claude/skills/gh-actions-node24-migration/scripts/audit.py .` reports every action as `node24`
- [ ] `python3 .claude/skills/skill-authoring/scripts/lint_skill.py .claude/skills/gh-actions-node24-migration` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)