### PR TITLE
fix(model): prevent GenerateFeedID panic on leading-zero hash (#113)

### DIFF
--- a/model/feed_id.go
+++ b/model/feed_id.go
@@ -28,7 +28,7 @@ func GenerateFeedID(feedURL string) string {
 		if len(slug) > 40 {
 			h := fnv.New32a()
 			_, _ = h.Write([]byte(feedURL)) // FNV hash Write never returns an error
-			hashStr := fmt.Sprintf("%x", h.Sum32())[:8]
+			hashStr := fmt.Sprintf("%08x", h.Sum32())
 			slug = slug[:32] + "-" + hashStr
 		}
 		return slug

--- a/model/feed_id_test.go
+++ b/model/feed_id_test.go
@@ -35,6 +35,14 @@ func TestGenerateFeedID(t *testing.T) {
 			feedURL:  "https://example.com/news & events/feed.xml",
 			expected: "example.com-news-events-feed-xml", // Spaces and & replaced with single dash
 		},
+		{
+			// Regression test for #113: FNV-32a hash with a leading zero nibble
+			// (Sum32 < 0x10000000) would render as < 8 hex chars under %x and
+			// panic when sliced to [:8]. Zero-padding via %08x prevents this.
+			name:     "Long URL with leading-zero hash",
+			feedURL:  "https://very-long-domain-name-example.com/p22/feed.xml",
+			expected: "very-long-domain-name-example.co-001353e5",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- Fixes #113: `GenerateFeedID` panics with `slice bounds out of range [:8]` when the FNV-32a hash of a long feed URL has leading zero nibbles
- Replace `fmt.Sprintf("%x", h.Sum32())[:8]` with `fmt.Sprintf("%08x", h.Sum32())` — zero-padding to 8 chars makes the slice unnecessary
- Regression test added using `https://very-long-domain-name-example.com/p22/feed.xml`, whose FNV-32a hash is `0x001353e5` (renders as 6 chars under `%x`, would have crashed pre-fix)

## Notes
- The issue report mentions CRC32, but the actual code uses FNV-32a (`hash/fnv`, per project convention). Root cause and fix are identical — both 32-bit hashes can produce values whose `%x` representation is shorter than 8 chars.
- The fallback branch (line 40) also uses `%x` but does not slice, so no panic risk there; leaving unchanged.

## Test plan
- [x] `go test ./model/` passes, including new regression case
- [x] `go vet ./model/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)