### PR TITLE
fix(store): lazy startup + per-host rate limiting (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,32 +267,42 @@ go run main.go run \
 
 ### Rate Limiting
 
-The feed-mcp server includes built-in rate limiting to be respectful to feed servers:
+The feed-mcp server applies a **per-host** token-bucket rate limit so it can be polite to any single feed server without artificially serialising fetches across many distinct hosts.
 
-**Default Settings:**
+**Default Settings (per host):**
 - 2 requests per second
 - Burst capacity of 5 requests
-- Applied to all HTTP requests made by the feed parser
+- Each remote host gets its own independent limiter, created on first use
 
 **How it Works:**
 - Uses `golang.org/x/time/rate` for token bucket rate limiting
-- Implements a custom `RateLimitedTransport` that wraps `http.RoundTripper`
+- `RateLimitedTransport` holds a `sync.Map` of `*rate.Limiter` keyed by `req.URL.Hostname()`
 - Automatically applied when no custom HTTP client is provided
-- Rate limiting occurs at the HTTP transport layer, ensuring all feed requests are controlled
+- Multiple subreddits on `www.reddit.com` share one limiter; feeds on distinct hosts run in parallel
 
-**Configuration:**
-Rate limiting is configured in the `store.Config` struct:
+**CLI flags:**
+```bash
+# Use defaults (2 req/s, burst 5, per host)
+go run main.go run https://example.com/feed.xml
+
+# Custom per-host limits
+go run main.go run --requests-per-second 5 --burst-capacity 10 https://example.com/feed.xml
+```
+
+**Programmatic Configuration:**
 ```go
 config := store.Config{
     Feeds:             []string{"https://example.com/feed.xml"},
-    RequestsPerSecond: 1.0,  // 1 request per second
-    BurstCapacity:     3,    // Allow burst of 3 requests
+    RequestsPerSecond: 1.0,  // 1 request per second per host
+    BurstCapacity:     3,    // 3-request burst per host
 }
 ```
 
+**History:** Prior to issue #114 the limiter was global. A single 2 req/s bucket across all hosts plus an eager pre-fetch of every feed at startup caused MCP `initialize` to time out on large OPML files (~80s for 164 feeds). The fix moved fetches off the startup path (lazy cache population) and split the limiter per host.
+
 **Customization:**
 - Pass a custom `HttpClient` to bypass built-in rate limiting
-- Adjust `RequestsPerSecond` and `BurstCapacity` for different rate limits
+- Adjust `RequestsPerSecond` and `BurstCapacity` for different per-host limits
 - Set to 0 or negative values to use sensible defaults
 
 ### Circuit Breaker Pattern

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -23,6 +23,9 @@ type RunCmd struct {
 	MaxConnsPerHost     int           `name:"max-conns-per-host" default:"10" help:"Maximum number of connections per host."`
 	MaxIdleConnsPerHost int           `name:"max-idle-conns-per-host" default:"5" help:"Maximum number of idle connections per host."`
 	IdleConnTimeout     time.Duration `name:"idle-conn-timeout" default:"90s" help:"How long an idle connection remains idle before closing."`
+	// Rate limiting settings (applied per host)
+	RequestsPerSecond float64 `name:"requests-per-second" default:"2" help:"Per-host rate limit for outbound feed requests (requests per second)."`
+	BurstCapacity     int     `name:"burst-capacity" default:"5" help:"Per-host rate-limit burst capacity (max immediate requests before throttling)."`
 	// Retry mechanism settings
 	RetryMaxAttempts int           `name:"retry-max-attempts" default:"3" help:"Maximum number of retry attempts for failed feed fetches."`
 	RetryBaseDelay   time.Duration `name:"retry-base-delay" default:"1s" help:"Base delay for exponential backoff between retry attempts."`
@@ -82,6 +85,8 @@ func (c *RunCmd) Run(globals *model.Globals, ctx context.Context) error {
 		OPML:                c.OPML, // Pass OPML path for metadata source detection
 		Timeout:             c.Timeout,
 		ExpireAfter:         c.ExpireAfter,
+		RequestsPerSecond:   c.RequestsPerSecond,
+		BurstCapacity:       c.BurstCapacity,
 		MaxIdleConns:        c.MaxIdleConns,
 		MaxConnsPerHost:     c.MaxConnsPerHost,
 		MaxIdleConnsPerHost: c.MaxIdleConnsPerHost,

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/alecthomas/kong"
+
 	"github.com/richardwooding/feed-mcp/model"
 )
 
@@ -80,3 +82,47 @@ func (c *RunCmd) parseConfig() (any, error) {
 }
 
 var ErrNoFeeds = errors.New("no feeds specified")
+
+// TestRunCmd_RateLimitFlagsDefaults verifies that --requests-per-second and
+// --burst-capacity have the documented defaults when omitted from the CLI.
+func TestRunCmd_RateLimitFlagsDefaults(t *testing.T) {
+	type cli struct {
+		Run RunCmd `cmd:""`
+	}
+	c := &cli{}
+	parser, err := kong.New(c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"run", "http://example.com/feed"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Run.RequestsPerSecond != 2 {
+		t.Errorf("default RequestsPerSecond = %v, want 2", c.Run.RequestsPerSecond)
+	}
+	if c.Run.BurstCapacity != 5 {
+		t.Errorf("default BurstCapacity = %v, want 5", c.Run.BurstCapacity)
+	}
+}
+
+// TestRunCmd_RateLimitFlagsOverride verifies that --requests-per-second and
+// --burst-capacity propagate from CLI args onto the RunCmd struct.
+func TestRunCmd_RateLimitFlagsOverride(t *testing.T) {
+	type cli struct {
+		Run RunCmd `cmd:""`
+	}
+	c := &cli{}
+	parser, err := kong.New(c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"run", "--requests-per-second", "7.5", "--burst-capacity", "20", "http://example.com/feed"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Run.RequestsPerSecond != 7.5 {
+		t.Errorf("RequestsPerSecond = %v, want 7.5", c.Run.RequestsPerSecond)
+	}
+	if c.Run.BurstCapacity != 20 {
+		t.Errorf("BurstCapacity = %v, want 20", c.Run.BurstCapacity)
+	}
+}

--- a/store/dynamic_feeds.go
+++ b/store/dynamic_feeds.go
@@ -346,10 +346,18 @@ func (ds *DynamicStore) ListManagedFeeds(ctx context.Context) ([]mcpserver.Manag
 			lastFetched = metadata.LastFetched // Keep original if cache fetch failed
 		}
 
+		// Title falls back to the freshly-fetched cacheInfo.Title when metadata
+		// is blank — startup/OPML feeds seed empty titles (see #114 lazy init)
+		// and rely on the first list_managed_feeds call to surface the real title.
+		title := metadata.Title
+		if title == "" && cacheInfo.Found {
+			title = cacheInfo.Title
+		}
+
 		feeds = append(feeds, mcpserver.ManagedFeedInfo{
 			FeedID:      feedID,
 			URL:         url,
-			Title:       metadata.Title,
+			Title:       title,
 			Category:    metadata.Category,
 			Description: metadata.Description,
 			Status:      status,

--- a/store/dynamic_feeds.go
+++ b/store/dynamic_feeds.go
@@ -122,29 +122,25 @@ func (ds *DynamicStore) checkFeedCache(ctx context.Context, url string) feedCach
 	return info
 }
 
-// initializeStartupFeedMetadata creates metadata entries for feeds loaded at startup
+// initializeStartupFeedMetadata creates metadata entries for feeds loaded at startup.
+// Titles are deliberately left blank here; populating them required a synchronous
+// fetch per feed which blocked NewDynamicStore for tens of seconds on large feed
+// lists (issue #114). Title and LastFetched are populated on first read via
+// list_managed_feeds or the regular feed access paths.
 func (ds *DynamicStore) initializeStartupFeedMetadata() {
 	ds.dynamicMutex.Lock()
 	defer ds.dynamicMutex.Unlock()
 
-	for feedID, url := range ds.feeds {
-		// Determine source based on how feeds were loaded
-		source := mcpserver.FeedSourceStartup
-		if ds.config.OPML != "" {
-			source = mcpserver.FeedSourceOPML
-		}
+	source := mcpserver.FeedSourceStartup
+	if ds.config.OPML != "" {
+		source = mcpserver.FeedSourceOPML
+	}
 
+	for feedID := range ds.feeds {
 		ds.feedMetadata[feedID] = &DynamicFeedMetadata{
 			AddedAt: time.Now(), // Approximate startup time
 			Source:  source,
 			Status:  statusActive,
-		}
-
-		// Try to get feed title from cache
-		cacheInfo := ds.checkFeedCache(context.Background(), url)
-		if cacheInfo.Found {
-			ds.feedMetadata[feedID].Title = cacheInfo.Title
-			ds.feedMetadata[feedID].LastFetched = cacheInfo.LastFetched
 		}
 	}
 }

--- a/store/dynamic_feeds_test.go
+++ b/store/dynamic_feeds_test.go
@@ -9,6 +9,32 @@ import (
 	"github.com/richardwooding/feed-mcp/mcpserver"
 )
 
+// TestDynamicStore_LazyStartup verifies that NewDynamicStore returns quickly
+// even when configured feeds are unreachable. The pre-#114 code called
+// checkFeedCache for every startup feed inside initializeStartupFeedMetadata,
+// blocking constructor return until each feed timed out under the rate limiter.
+func TestDynamicStore_LazyStartup(t *testing.T) {
+	urls := []string{
+		"http://127.0.0.1:1/dynamic-a",
+		"http://127.0.0.2:1/dynamic-b",
+		"http://127.0.0.3:1/dynamic-c",
+	}
+	cfg := Config{Feeds: urls, AllowPrivateIPs: true}
+
+	start := time.Now()
+	ds, err := NewDynamicStore(&cfg, false)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("NewDynamicStore failed: %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("NewDynamicStore took %v; expected <500ms (suggests eager metadata fetch)", elapsed)
+	}
+	if len(ds.feedMetadata) != len(urls) {
+		t.Errorf("expected %d metadata entries, got %d", len(urls), len(ds.feedMetadata))
+	}
+}
+
 // TestDynamicStore_NewDynamicStore tests the creation of a new dynamic store
 func TestDynamicStore_NewDynamicStore(t *testing.T) {
 	config := Config{

--- a/store/dynamic_feeds_test.go
+++ b/store/dynamic_feeds_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +34,41 @@ func TestDynamicStore_LazyStartup(t *testing.T) {
 	}
 	if len(ds.feedMetadata) != len(urls) {
 		t.Errorf("expected %d metadata entries, got %d", len(urls), len(ds.feedMetadata))
+	}
+}
+
+// TestDynamicStore_ListManagedFeeds_TitleFallback verifies that startup feeds —
+// which now seed empty metadata.Title (lazy init from #114) — surface the real
+// title from the cache on the first list_managed_feeds call.
+func TestDynamicStore_ListManagedFeeds_TitleFallback(t *testing.T) {
+	const wantTitle = "Startup Feed Title"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(`<rss version="2.0"><channel><title>` + wantTitle + `</title><item><title>i</title><link>http://example.com/1</link></item></channel></rss>`))
+	}))
+	defer srv.Close()
+
+	ds, err := NewDynamicStore(&Config{Feeds: []string{srv.URL}, AllowPrivateIPs: true}, true)
+	if err != nil {
+		t.Fatalf("NewDynamicStore: %v", err)
+	}
+
+	// Sanity: startup metadata is seeded with an empty title (lazy init).
+	for _, md := range ds.feedMetadata {
+		if md.Title != "" {
+			t.Fatalf("expected empty seed Title, got %q", md.Title)
+		}
+	}
+
+	got, err := ds.ListManagedFeeds(context.Background())
+	if err != nil {
+		t.Fatalf("ListManagedFeeds: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 managed feed, got %d", len(got))
+	}
+	if got[0].Title != wantTitle {
+		t.Errorf("Title = %q, want %q (fallback to cacheInfo.Title not applied)", got[0].Title, wantTitle)
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -76,28 +76,37 @@ type Store struct {
 	metricsMutex     sync.RWMutex
 }
 
-// RateLimitedTransport wraps an http.RoundTripper with rate limiting
+// RateLimitedTransport wraps an http.RoundTripper with per-host rate limiting.
+// A separate token bucket is maintained for each remote host so that fetches
+// against many distinct hosts are not artificially serialized, while requests
+// to any single host remain bounded by the configured rate and burst.
 type RateLimitedTransport struct {
-	transport   http.RoundTripper
-	rateLimiter *rate.Limiter
+	transport         http.RoundTripper
+	requestsPerSecond rate.Limit
+	burstCapacity     int
+	limiters          sync.Map // host (string) -> *rate.Limiter
 }
 
-// RoundTrip implements the http.RoundTripper interface with rate limiting
+// limiterForHost returns the limiter associated with host, creating one on first use.
+func (r *RateLimitedTransport) limiterForHost(host string) *rate.Limiter {
+	if v, ok := r.limiters.Load(host); ok {
+		return v.(*rate.Limiter)
+	}
+	v, _ := r.limiters.LoadOrStore(host, rate.NewLimiter(r.requestsPerSecond, r.burstCapacity))
+	return v.(*rate.Limiter)
+}
+
+// RoundTrip implements the http.RoundTripper interface with per-host rate limiting.
 func (r *RateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Wait for rate limiter permission
-	err := r.rateLimiter.Wait(req.Context())
-	if err != nil {
+	if err := r.limiterForHost(req.URL.Hostname()).Wait(req.Context()); err != nil {
 		return nil, err
 	}
-
-	// Proceed with the actual request
 	return r.transport.RoundTrip(req)
 }
 
-// NewRateLimitedHTTPClient creates an HTTP client with rate limiting and connection pooling
+// NewRateLimitedHTTPClient creates an HTTP client with per-host rate limiting and connection pooling.
+// The requestsPerSecond and burstCapacity arguments configure each host's token bucket independently.
 func NewRateLimitedHTTPClient(requestsPerSecond float64, burstCapacity int, poolConfig HTTPPoolConfig) *http.Client {
-	limiter := rate.NewLimiter(rate.Limit(requestsPerSecond), burstCapacity)
-
 	// Create a custom transport with connection pooling settings
 	baseTransport := &http.Transport{
 		MaxIdleConns:        poolConfig.MaxIdleConns,
@@ -116,8 +125,9 @@ func NewRateLimitedHTTPClient(requestsPerSecond float64, burstCapacity int, pool
 	}
 
 	transport := &RateLimitedTransport{
-		transport:   baseTransport,
-		rateLimiter: limiter,
+		transport:         baseTransport,
+		requestsPerSecond: rate.Limit(requestsPerSecond),
+		burstCapacity:     burstCapacity,
 	}
 
 	return &http.Client{
@@ -503,21 +513,15 @@ func newStoreInternal(config Config) (*Store, error) {
 	)
 	s.feedCacheManager = cacheManager
 
+	// Build the ID-to-URL map synchronously without fetching. The cache populates
+	// lazily on the first GetAllFeeds / GetFeedAndItems call via the LoadableCache
+	// loader above. Pre-fetching here previously blocked NewStore for ~(n/rps)
+	// seconds with a global rate limiter and caused MCP initialize timeouts on
+	// large feed lists (issue #114).
 	feeds := make(map[string]string, len(config.Feeds))
-	var feedsMutex sync.Mutex
-	wg := sync.WaitGroup{}
 	for _, feedURL := range config.Feeds {
-		wg.Add(1)
-		go func(url string) {
-			defer wg.Done()
-			id := model.GenerateFeedID(url)
-			feedsMutex.Lock()
-			feeds[id] = url
-			feedsMutex.Unlock()
-			_, _ = cacheManager.Get(context.Background(), url)
-		}(feedURL)
+		feeds[model.GenerateFeedID(feedURL)] = feedURL
 	}
-	wg.Wait()
 
 	s.feeds = feeds
 	return s, nil

--- a/store/store.go
+++ b/store/store.go
@@ -98,7 +98,8 @@ func (r *RateLimitedTransport) limiterForHost(host string) *rate.Limiter {
 
 // RoundTrip implements the http.RoundTripper interface with per-host rate limiting.
 func (r *RateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if err := r.limiterForHost(req.URL.Hostname()).Wait(req.Context()); err != nil {
+	host := strings.ToLower(req.URL.Hostname())
+	if err := r.limiterForHost(host).Wait(req.Context()); err != nil {
 		return nil, err
 	}
 	return r.transport.RoundTrip(req)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -978,21 +978,13 @@ func TestRetryMechanism_ExhaustsRetries(t *testing.T) {
 		CircuitBreakerEnabled: &disabled,
 	}
 
-	// Reset counter before NewStore call since it will trigger initial fetch
-	atomic.StoreInt64(&requestCount, 0)
-
 	store, err := NewStore(&config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// NewStore should have made exactly 3 attempts (retries during initialization)
-	initCount := atomic.LoadInt64(&requestCount)
-	if initCount != 3 {
-		t.Errorf("expected 3 requests during NewStore, got %d", initCount)
-	}
-
-	// Reset counter to test fresh fetch
+	// NewStore no longer triggers fetches eagerly (see #114). Counter is reset
+	// here so the assertion below measures only the GetAllFeeds-triggered fetch.
 	atomic.StoreInt64(&requestCount, 0)
 
 	feeds, err := store.GetAllFeeds(context.Background())
@@ -1009,7 +1001,7 @@ func TestRetryMechanism_ExhaustsRetries(t *testing.T) {
 		t.Error("expected fetch error, got none")
 	}
 
-	// Should have made exactly 3 more attempts
+	// Should have made exactly 3 attempts (1 initial + 2 retries)
 	finalCount := atomic.LoadInt64(&requestCount)
 	if finalCount != 3 {
 		t.Errorf("expected 3 requests during GetAllFeeds, got %d", finalCount)
@@ -1039,21 +1031,12 @@ func TestRetryMechanism_NonRetryableError(t *testing.T) {
 		CircuitBreakerEnabled: &disabled,
 	}
 
-	// Reset counter before NewStore call since it will trigger initial fetch
-	atomic.StoreInt64(&requestCount, 0)
-
 	store, err := NewStore(&config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// NewStore should have made only 1 attempt (4xx errors are not retryable)
-	initCount := atomic.LoadInt64(&requestCount)
-	if initCount != 1 {
-		t.Errorf("expected 1 request during NewStore, got %d", initCount)
-	}
-
-	// Reset counter to test fresh fetch
+	// NewStore no longer triggers fetches eagerly (see #114).
 	atomic.StoreInt64(&requestCount, 0)
 
 	feeds, err := store.GetAllFeeds(context.Background())
@@ -1102,21 +1085,12 @@ func TestRetryMechanism_ExponentialBackoff(t *testing.T) {
 		CircuitBreakerEnabled: &disabled,
 	}
 
-	// Reset counters before NewStore call since it will trigger initial fetch
-	atomic.StoreInt64(&requestCount, 0)
-	timestamps = nil
-
 	store, err := NewStore(&config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Verify NewStore made 3 attempts with proper timing
-	if len(timestamps) != 3 {
-		t.Fatalf("expected 3 timestamps during NewStore, got %d", len(timestamps))
-	}
-
-	// Reset for GetAllFeeds test
+	// NewStore no longer triggers fetches eagerly (see #114).
 	atomic.StoreInt64(&requestCount, 0)
 	timestamps = nil
 
@@ -1309,19 +1283,14 @@ func TestRetryMechanism_DefaultConfiguration(t *testing.T) {
 		// Don't set retry values to test defaults (should be 3 attempts, 1s base delay)
 	}
 
-	// Reset counter
-	atomic.StoreInt64(&requestCount, 0)
-
 	store, err := NewStore(&config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// NewStore should succeed after 3 attempts (default retry max attempts)
-	initCount := atomic.LoadInt64(&requestCount)
-	if initCount != 3 {
-		t.Errorf("expected 3 requests during NewStore with defaults, got %d", initCount)
-	}
+	// NewStore no longer triggers fetches eagerly (see #114). Reset and let
+	// GetAllFeeds drive the retry path with default RetryMaxAttempts=3.
+	atomic.StoreInt64(&requestCount, 0)
 
 	// Verify the store was created successfully and defaults worked
 	feeds, err := store.GetAllFeeds(context.Background())
@@ -1362,25 +1331,13 @@ func TestRetryMetrics_SuccessfulFeeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get initial metrics
+	// NewStore no longer triggers fetches eagerly (#114), so metrics start at zero.
 	initialMetrics := store.GetRetryMetrics()
-
-	// Should have 1 successful feed from initialization
-	if initialMetrics.SuccessfulFeeds != 1 {
-		t.Errorf("expected 1 successful feed in initial metrics, got %d", initialMetrics.SuccessfulFeeds)
-	}
-	if initialMetrics.TotalAttempts != 1 {
-		t.Errorf("expected 1 total attempt in initial metrics, got %d", initialMetrics.TotalAttempts)
-	}
-	if initialMetrics.TotalRetries != 0 {
-		t.Errorf("expected 0 retries in initial metrics, got %d", initialMetrics.TotalRetries)
-	}
-	if initialMetrics.RetrySuccessRate != 100.0 {
-		t.Errorf("expected 100%% success rate in initial metrics, got %f", initialMetrics.RetrySuccessRate)
+	if initialMetrics.TotalAttempts != 0 {
+		t.Errorf("expected 0 attempts before any fetch, got %d", initialMetrics.TotalAttempts)
 	}
 
-	// Wait for cache to expire then fetch again to trigger cache miss
-	time.Sleep(10 * time.Millisecond) // Wait for cache expiration
+	// Trigger a fetch via the lazy load path.
 	feeds, err := store.GetAllFeeds(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -1390,21 +1347,18 @@ func TestRetryMetrics_SuccessfulFeeds(t *testing.T) {
 		t.Fatalf("expected 1 feed, got %d", len(feeds))
 	}
 
-	// Get final metrics
 	finalMetrics := store.GetRetryMetrics()
-
-	// Should have 2 successful feeds total
-	if finalMetrics.SuccessfulFeeds != 2 {
-		t.Errorf("expected 2 successful feeds in final metrics, got %d", finalMetrics.SuccessfulFeeds)
+	if finalMetrics.SuccessfulFeeds != 1 {
+		t.Errorf("expected 1 successful feed, got %d", finalMetrics.SuccessfulFeeds)
 	}
-	if finalMetrics.TotalAttempts != 2 {
-		t.Errorf("expected 2 total attempts in final metrics, got %d", finalMetrics.TotalAttempts)
+	if finalMetrics.TotalAttempts != 1 {
+		t.Errorf("expected 1 total attempt, got %d", finalMetrics.TotalAttempts)
 	}
 	if finalMetrics.TotalRetries != 0 {
-		t.Errorf("expected 0 retries in final metrics, got %d", finalMetrics.TotalRetries)
+		t.Errorf("expected 0 retries, got %d", finalMetrics.TotalRetries)
 	}
 	if finalMetrics.RetrySuccessRate != 100.0 {
-		t.Errorf("expected 100%% success rate in final metrics, got %f", finalMetrics.RetrySuccessRate)
+		t.Errorf("expected 100%% success rate, got %f", finalMetrics.RetrySuccessRate)
 	}
 }
 
@@ -1448,15 +1402,17 @@ func TestRetryMetrics_WithRetries(t *testing.T) {
 		CircuitBreakerEnabled: &disabled,
 	}
 
-	// Reset counter
-	atomic.StoreInt64(&requestCount, 0)
-
 	store, err := NewStore(&config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Get metrics after initialization
+	// NewStore is lazy (#114); drive the retry path via GetAllFeeds.
+	atomic.StoreInt64(&requestCount, 0)
+	if _, err := store.GetAllFeeds(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
 	metrics := store.GetRetryMetrics()
 
 	// Should have 1 successful feed with retries
@@ -1500,15 +1456,17 @@ func TestRetryMetrics_FailedFeeds(t *testing.T) {
 		CircuitBreakerEnabled: &disabled,
 	}
 
-	// Reset counter
-	atomic.StoreInt64(&requestCount, 0)
-
 	store, err := NewStore(&config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Get metrics after initialization
+	// NewStore is lazy (#114); drive the retry path via GetAllFeeds.
+	atomic.StoreInt64(&requestCount, 0)
+	if _, err := store.GetAllFeeds(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
 	metrics := store.GetRetryMetrics()
 
 	// Should have 1 failed feed with retries
@@ -1557,7 +1515,11 @@ func TestRetryMetrics_MixedResults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get metrics after initialization
+	// NewStore is lazy (#114); drive both feed fetches via GetAllFeeds.
+	if _, err := store.GetAllFeeds(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
 	metrics := store.GetRetryMetrics()
 
 	// Should have mixed results
@@ -1579,5 +1541,119 @@ func TestRetryMetrics_MixedResults(t *testing.T) {
 	expectedSuccessRate := 50.0
 	if metrics.RetrySuccessRate != expectedSuccessRate {
 		t.Errorf("expected %.1f%% success rate, got %f", expectedSuccessRate, metrics.RetrySuccessRate)
+	}
+}
+
+// TestNewStore_LazyStartup verifies that NewStore returns quickly even when
+// configured feeds are unreachable. The pre-#114 implementation eagerly fetched
+// every feed and blocked NewStore until the rate-limited retry chain finished,
+// which could exceed the MCP initialize handshake window.
+func TestNewStore_LazyStartup(t *testing.T) {
+	// Several unreachable URLs across distinct hosts. With the eager prefetch
+	// each would have stalled for retries × timeout; with lazy startup the
+	// constructor should return without making any network calls.
+	urls := []string{
+		"http://127.0.0.1:1/feed-a",
+		"http://127.0.0.2:1/feed-b",
+		"http://127.0.0.3:1/feed-c",
+	}
+
+	start := time.Now()
+	s, err := NewStore(&Config{Feeds: urls, AllowPrivateIPs: true})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	// Generous bound: lazy construction is microseconds; allow CI variance.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("NewStore took %v; expected <500ms (suggests eager prefetch)", elapsed)
+	}
+	if len(s.feeds) != len(urls) {
+		t.Errorf("expected %d feeds registered, got %d", len(urls), len(s.feeds))
+	}
+}
+
+// fakeRoundTripper returns an empty 200 response without making a network call,
+// so RateLimitedTransport tests measure only the limiter's wait time.
+type fakeRoundTripper struct{}
+
+func (f *fakeRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}, nil
+}
+
+// newTestRequest builds a GET request for the given hostname (no real network use).
+func newTestRequest(t *testing.T, host string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "http://"+host+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	return req
+}
+
+// TestRateLimitedTransport_PerHost verifies that requests to different hosts
+// proceed in parallel rather than serializing through a global limiter.
+func TestRateLimitedTransport_PerHost(t *testing.T) {
+	rt := &RateLimitedTransport{
+		transport:         &fakeRoundTripper{},
+		requestsPerSecond: 1.0, // very restrictive: a global limiter would force ~1s wait
+		burstCapacity:     1,
+	}
+
+	start := time.Now()
+	done := make(chan error, 2)
+	for _, host := range []string{"host-a.example", "host-b.example"} {
+		go func(h string) {
+			resp, err := rt.RoundTrip(newTestRequest(t, h))
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+			done <- err
+		}(host)
+	}
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatalf("RoundTrip failed: %v", err)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// With per-host limiters each host has its own burst token, so both calls
+	// proceed immediately. A global limiter at burst 1 would force the second
+	// caller to wait ~1 second.
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("parallel cross-host requests took %v; expected <200ms with per-host limiting", elapsed)
+	}
+}
+
+// TestRateLimitedTransport_SameHostStillLimited verifies the per-host limiter
+// still throttles repeated requests to the same host.
+func TestRateLimitedTransport_SameHostStillLimited(t *testing.T) {
+	rt := &RateLimitedTransport{
+		transport:         &fakeRoundTripper{},
+		requestsPerSecond: 5.0, // 200ms per token after burst is spent
+		burstCapacity:     1,
+	}
+
+	start := time.Now()
+	for i := 0; i < 2; i++ {
+		resp, err := rt.RoundTrip(newTestRequest(t, "host-c.example"))
+		if err != nil {
+			t.Fatalf("RoundTrip %d failed: %v", i, err)
+		}
+		_ = resp.Body.Close()
+	}
+	elapsed := time.Since(start)
+
+	// First request consumes the burst token; second waits ~200ms for a refill.
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("two same-host requests took only %v; expected ~200ms throttle", elapsed)
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("two same-host requests took %v; throttling too aggressive", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #114: MCP `initialize` handshake timing out when loading large OPML files (the reporter had 164 feeds). Two compounding causes — an eager pre-fetch of every feed during `NewStore` and a global 2 req/s rate limiter — made `NewStore` block for ~80 s before the server could respond.

Three coordinated changes plus a small CLI ergonomics improvement:

### 1. Lazy cache population — `store/store.go`
`newStoreInternal` no longer spawns a goroutine per feed to pre-fetch. It builds the ID→URL map synchronously; the existing `LoadableCache` populates lazily on the first `GetAllFeeds` / `GetFeedAndItems` call.

### 2. Per-host rate limiter — `store/store.go`
`RateLimitedTransport` now keeps one `*rate.Limiter` per host (sync.Map keyed by `req.URL.Hostname()`). Politeness toward any single server is preserved; cross-host traffic is no longer artificially serialised. Multiple subreddits on `www.reddit.com` still share one limiter; feeds on distinct hosts run in parallel.

### 3. Lazy DynamicStore startup — `store/dynamic_feeds.go`
`initializeStartupFeedMetadata` previously called `checkFeedCache` per feed, blocking `NewDynamicStore` when `--allow-runtime-feeds` was combined with `--opml`. The fetch is removed; metadata starts with empty `Title` and is populated on demand.

### 4. New CLI flags — `cmd/cmd.go`
`--requests-per-second` (default 2) and `--burst-capacity` (default 5) expose the existing `store.Config` fields. Defaults preserve current per-host behaviour for single-host users.

## Behaviour changes worth flagging

- **Cache is no longer pre-warmed at startup.** The first MCP tool call after launch triggers fetches. This is the intended behaviour for resolving the handshake timeout.
- **Rate limiter is now per host rather than global.** For users with all feeds on a single host (rare for OPML setups), behaviour is unchanged. For users with feeds spread across many hosts (the issue reporter's case), throughput is no longer artificially capped.
- **`DynamicStore.AddFeed` still synchronously fetches** to populate title metadata (lines ~209) — this is request-scoped, not startup-blocking, so it does not affect #114. Flagged as a potential follow-up.

## Test plan

- [x] New: `TestNewStore_LazyStartup` — `NewStore` returns in <500 ms with unreachable URLs (would have blocked under retry+timeout previously).
- [x] New: `TestDynamicStore_LazyStartup` — same for `NewDynamicStore`.
- [x] New: `TestRateLimitedTransport_PerHost` — two concurrent requests to distinct hosts at `1 rps, burst 1` complete in <200 ms.
- [x] New: `TestRateLimitedTransport_SameHostStillLimited` — same-host requests still throttled.
- [x] New: `TestRunCmd_RateLimitFlags{Defaults,Override}` — flag wiring.
- [x] Existing retry-mechanism tests updated to drive fetches via an explicit `GetAllFeeds` call now that `NewStore` is lazy.
- [x] `go test ./...` — all packages green.
- [x] `golangci-lint v2 run ./...` — no new lint issues introduced (220 pre-existing, count unchanged).

## Docs

`CLAUDE.md`'s Rate Limiting section updated to describe per-host semantics and the new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)