### PR TITLE
feat: implement HTTP+SSE transport for MCP server

### DIFF
--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -508,11 +509,54 @@ func (s *Server) runTransport(ctx context.Context, srv *mcp.Server) error {
 	case model.StdioTransport:
 		return srv.Run(ctx, &mcp.StdioTransport{})
 	case model.HTTPWithSSETransport:
-		return srv.Run(ctx, &mcp.StreamableServerTransport{SessionID: s.sessionID})
+		return s.runHTTPTransport(ctx, srv)
 	default:
 		return model.NewFeedError(model.ErrorTypeTransport, "unsupported transport").
 			WithOperation("run_server").
 			WithComponent("mcp_server")
+	}
+}
+
+// runHTTPTransport starts the HTTP server with SSE transport
+func (s *Server) runHTTPTransport(ctx context.Context, srv *mcp.Server) error {
+	// Get port from environment variable, default to 8080
+	port := "8080"
+	if envPort := os.Getenv("PORT"); envPort != "" {
+		port = envPort
+	}
+
+	// Create SSE handler - returns our MCP server for all requests
+	handler := mcp.NewSSEHandler(func(request *http.Request) *mcp.Server {
+		// Return the same server instance for all paths
+		return srv
+	}, nil)
+
+	// Create HTTP server
+	httpServer := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: handler,
+	}
+
+	// Channel to receive server errors
+	errCh := make(chan error, 1)
+
+	// Start HTTP server in goroutine
+	go func() {
+		fmt.Printf("Starting HTTP+SSE server on port %s\n", port)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	// Wait for context cancellation or server error
+	select {
+	case <-ctx.Done():
+		// Graceful shutdown
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return httpServer.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
 	}
 }
 


### PR DESCRIPTION
Implements proper HTTP server for the http-with-sse transport mode, which was previously non-functional.

## Problem
The existing http-with-sse transport implementation passed StreamableServerTransport to srv.Run() but never created an actual HTTP server. This resulted in no port being bound and the server being unreachable over HTTP.

## Solution
Following the official MCP Go SDK pattern (examples/server/sse/main.go):
- Create HTTP server using http.Server
- Use mcp.NewSSEHandler() to wrap the MCP server
- Listen on PORT environment variable (default: 8080)
- Implement graceful shutdown via context cancellation

## Changes
- Added runHTTPTransport() method that creates HTTP server with SSE handler
- Modified runTransport() to call runHTTPTransport for HTTP+SSE mode
- Added os import for PORT environment variable support

## Testing
Tested with Docker:
- Server starts successfully on port 8080
- Responds to HTTP requests
- SSE endpoint working correctly
- Tested with Cursor IDE MCP client

## Breaking Changes
None. The stdio transport remains unchanged and this fix only affects the previously non-functional http-with-sse transport mode.