### PR TITLE
feat(transport): implement Streamable HTTP transport per MCP spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,13 +157,13 @@ The architecture follows clean Go patterns with strong separation of concerns:
 2. **Store Initialization** → Creates feed store with caching layer
 3. **Feed Fetching** → Concurrent fetching of all configured feeds
 4. **MCP Server** → Exposes feeds via MCP protocol tools
-5. **Transport Layer** → Handles stdio or HTTP-SSE communication
+5. **Transport Layer** → Handles stdio or Streamable HTTP communication
 
 ### Package Structure
 
 **`model/` - Data Structures and Types**
 - Core domain models (`Feed`, `Item`, `Author`)
-- Transport enums (stdio, http-with-sse)
+- Transport enums (stdio, streamable-http; http-with-sse is deprecated)
 - Adapter functions (`FromGoFeed()` converts external → internal types)
 - Global configuration and constants
 
@@ -538,6 +538,48 @@ go run main.go run <feed-urls>
 - Comprehensive tests verify graceful shutdown behavior
 - Tests ensure server shuts down within expected timeouts
 - Context cancellation is properly tested across all components
+
+### Streamable HTTP Transport
+
+The feed-mcp server supports Streamable HTTP transport per the MCP specification, enabling HTTP-based communication with MCP clients.
+
+**Transport Options:**
+- `stdio` (default): Standard input/output for local CLI usage
+- `streamable-http`: HTTP server using Streamable HTTP protocol (recommended for HTTP)
+- `http-with-sse`: Deprecated, maps to `streamable-http` for backwards compatibility
+
+**Streamable HTTP Features:**
+- Uses `mcp.NewStreamableHTTPHandler()` from the official MCP Go SDK
+- Supports both stateful (session-based) and stateless modes
+- Configurable session timeouts for idle connection cleanup
+- Built-in DNS rebinding and cross-origin protection
+- Compatible with distributed/load-balanced deployments in stateless mode
+
+**CLI Configuration:**
+```bash
+# Start with Streamable HTTP transport (recommended)
+go run main.go run --transport=streamable-http <feed-urls>
+
+# Custom port (default: 8080, also reads PORT env var)
+go run main.go run --transport=streamable-http --http-port=3000 <feed-urls>
+
+# Stateless mode for distributed deployments
+go run main.go run --transport=streamable-http --http-stateless <feed-urls>
+
+# Custom session timeout (default: 30m)
+go run main.go run --transport=streamable-http --http-session-timeout=1h <feed-urls>
+
+# Backwards compatible (deprecated)
+go run main.go run --transport=http-with-sse <feed-urls>
+```
+
+**Docker Usage:**
+```bash
+# Run with Streamable HTTP transport
+docker run -p 8080:8080 -e PORT=8080 ghcr.io/richardwooding/feed-mcp:latest run --transport=streamable-http <feed-urls>
+```
+
+**Note:** The SSE-based transport (`http-with-sse`) is deprecated per the MCP specification (2024-11-05). Use `streamable-http` for all new deployments.
 
 ### URL Security and Validation
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -12,7 +12,7 @@ import (
 
 // RunCmd holds the command line arguments and flags for the run command
 type RunCmd struct {
-	Transport       string        `name:"transport" default:"stdio" enum:"stdio,http-with-sse" help:"Transport to use for the MCP server."`
+	Transport       string        `name:"transport" default:"stdio" enum:"stdio,http-with-sse,streamable-http" help:"Transport to use for the MCP server (streamable-http is recommended for HTTP)."`
 	Feeds           []string      `arg:"" name:"feeds" optional:"" help:"Feeds to list (cannot be used with --opml)."`
 	OPML            string        `name:"opml" help:"OPML file path or URL to load feed URLs from (cannot be used with feeds)."`
 	ExpireAfter     time.Duration `name:"expire-after" default:"1h" help:"Expire feeds after this duration."`
@@ -35,6 +35,10 @@ type RunCmd struct {
 	AllowPrivateIPs bool `name:"allow-private-ips" default:"false" help:"Allow feed URLs that resolve to private IP ranges or localhost (disabled by default for security)."`
 	// Runtime feed management settings
 	AllowRuntimeFeeds bool `name:"allow-runtime-feeds" default:"false" help:"Enable runtime feed management tools (add_feed, remove_feed, list_managed_feeds)."`
+	// HTTP server settings (for streamable-http transport)
+	HTTPPort           string        `name:"http-port" default:"8080" env:"PORT" help:"Port for HTTP server (streamable-http transport)."`
+	HTTPStateless      bool          `name:"http-stateless" default:"false" help:"Run HTTP server in stateless mode (no session tracking)."`
+	HTTPSessionTimeout time.Duration `name:"http-session-timeout" default:"30m" help:"Timeout for idle HTTP sessions."`
 }
 
 // Run executes the feed MCP server with the given configuration
@@ -99,7 +103,10 @@ func (c *RunCmd) Run(globals *model.Globals, ctx context.Context) error {
 	}
 
 	serverConfig := mcpserver.Config{
-		Transport: transport,
+		Transport:          transport,
+		HTTPPort:           c.HTTPPort,
+		HTTPStateless:      c.HTTPStateless,
+		HTTPSessionTimeout: c.HTTPSessionTimeout,
 	}
 
 	if c.AllowRuntimeFeeds {
@@ -121,7 +128,7 @@ func (c *RunCmd) Run(globals *model.Globals, ctx context.Context) error {
 		serverConfig.FeedAndItemsGetter = feedStore
 	}
 
-	server, err := mcpserver.NewServer(serverConfig)
+	server, err := mcpserver.NewServer(&serverConfig)
 	if err != nil {
 		return err
 	}

--- a/mcpserver/integration_test.go
+++ b/mcpserver/integration_test.go
@@ -83,7 +83,7 @@ func TestServerRunMethod(t *testing.T) {
 				FeedAndItemsGetter: mockFeedItems,
 			}
 
-			server, err := NewServer(config)
+			server, err := NewServer(&config)
 			if err != nil && !tt.expectErr {
 				t.Fatalf("NewServer() failed: %v", err)
 			}
@@ -173,7 +173,7 @@ func TestServerConfigValidation(t *testing.T) {
 	// Test various configuration edge cases
 	t.Run("all nil configuration", func(t *testing.T) {
 		config := Config{}
-		_, err := NewServer(config)
+		_, err := NewServer(&config)
 		if err == nil {
 			t.Error("NewServer() should fail with empty config")
 		}
@@ -183,7 +183,7 @@ func TestServerConfigValidation(t *testing.T) {
 		config := Config{
 			Transport: model.StdioTransport,
 		}
-		_, err := NewServer(config)
+		_, err := NewServer(&config)
 		if err == nil {
 			t.Error("NewServer() should fail with partial config")
 		}

--- a/mcpserver/mcp_integration_simple_test.go
+++ b/mcpserver/mcp_integration_simple_test.go
@@ -65,7 +65,7 @@ func setupIntegrationTestServer(t *testing.T) *Server {
 		FeedAndItemsGetter: mockFeedGetter,
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestMCPServerResourceHandlersRegistration(t *testing.T) {
 		FeedAndItemsGetter: mockFeedGetter,
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/mcpserver/prompts_test.go
+++ b/mcpserver/prompts_test.go
@@ -37,7 +37,7 @@ func createTestServer(t *testing.T) *Server {
 		FeedAndItemsGetter: mockFeedItems,
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("NewServer() failed: %v", err)
 	}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -70,6 +70,10 @@ type Config struct {
 	FeedAndItemsGetter FeedAndItemsGetter
 	DynamicFeedManager DynamicFeedManager // Optional: for runtime feed management
 	Transport          model.Transport
+	// HTTP server configuration (for streamable-http transport)
+	HTTPPort           string
+	HTTPStateless      bool
+	HTTPSessionTimeout time.Duration
 }
 
 // Server implements an MCP server for serving syndication feeds
@@ -84,6 +88,10 @@ type Server struct {
 	imageCircuitBreakers map[string]*gobreaker.CircuitBreaker // Circuit breakers per image host
 	imageCBMutex         sync.RWMutex                         // Protects imageCircuitBreakers map
 	httpClient           *http.Client                         // HTTP client for fetching images
+	// HTTP server configuration (for streamable-http transport)
+	httpPort           string
+	httpStateless      bool
+	httpSessionTimeout time.Duration
 }
 
 // generateSessionID creates a unique session ID for this server instance
@@ -93,7 +101,7 @@ func generateSessionID() string {
 }
 
 // NewServer creates a new MCP server with the given configuration
-func NewServer(config Config) (*Server, error) {
+func NewServer(config *Config) (*Server, error) {
 	if config.Transport == model.UndefinedTransport {
 		return nil, model.NewFeedError(model.ErrorTypeTransport, "transport must be specified").
 			WithOperation("create_server").
@@ -109,12 +117,25 @@ func NewServer(config Config) (*Server, error) {
 			WithOperation("create_server").
 			WithComponent("mcp_server")
 	}
+	// Set HTTP defaults if not specified
+	httpPort := config.HTTPPort
+	if httpPort == "" {
+		httpPort = "8080"
+	}
+	httpSessionTimeout := config.HTTPSessionTimeout
+	if httpSessionTimeout == 0 {
+		httpSessionTimeout = 30 * time.Minute
+	}
+
 	server := &Server{
 		transport:          config.Transport,
 		allFeedsGetter:     config.AllFeedsGetter,
 		feedAndItemsGetter: config.FeedAndItemsGetter,
 		dynamicFeedManager: config.DynamicFeedManager,
 		sessionID:          generateSessionID(),
+		httpPort:           httpPort,
+		httpStateless:      config.HTTPStateless,
+		httpSessionTimeout: httpSessionTimeout,
 	}
 
 	// Initialize image cache and HTTP client
@@ -507,12 +528,52 @@ func (s *Server) runTransport(ctx context.Context, srv *mcp.Server) error {
 	switch s.transport {
 	case model.StdioTransport:
 		return srv.Run(ctx, &mcp.StdioTransport{})
-	case model.HTTPWithSSETransport:
-		return srv.Run(ctx, &mcp.StreamableServerTransport{SessionID: s.sessionID})
+	case model.HTTPWithSSETransport, model.StreamableHTTPTransport:
+		return s.runStreamableHTTPTransport(ctx, srv)
 	default:
 		return model.NewFeedError(model.ErrorTypeTransport, "unsupported transport").
 			WithOperation("run_server").
 			WithComponent("mcp_server")
+	}
+}
+
+// runStreamableHTTPTransport starts the HTTP server with Streamable HTTP transport
+func (s *Server) runStreamableHTTPTransport(ctx context.Context, srv *mcp.Server) error {
+	// Create Streamable HTTP handler per MCP spec
+	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return srv
+	}, &mcp.StreamableHTTPOptions{
+		Stateless:      s.httpStateless,
+		SessionTimeout: s.httpSessionTimeout,
+	})
+
+	// Create HTTP server with security settings
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", s.httpPort),
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second, // Prevent Slowloris attacks
+	}
+
+	// Channel to receive server errors
+	errCh := make(chan error, 1)
+
+	// Start HTTP server in goroutine
+	go func() {
+		fmt.Printf("Starting Streamable HTTP server on port %s\n", s.httpPort)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	// Wait for context cancellation or server error
+	select {
+	case <-ctx.Done():
+		// Graceful shutdown
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return httpServer.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
 	}
 }
 

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -92,7 +92,7 @@ func TestNewServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server, err := NewServer(tt.config)
+			server, err := NewServer(&tt.config)
 
 			if tt.wantErr {
 				if err == nil {
@@ -150,12 +150,12 @@ func TestNewServerSessionIDUniqueness(t *testing.T) {
 	}
 
 	// Create multiple servers and verify they have unique session IDs
-	server1, err := NewServer(config)
+	server1, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
-	server2, err := NewServer(config)
+	server2, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
@@ -228,7 +228,7 @@ func TestServerToolsIntegration(t *testing.T) {
 		FeedAndItemsGetter: mockFeedItems,
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("NewServer() failed: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestServerWithErrors(t *testing.T) {
 			FeedAndItemsGetter: mockFeedItems,
 		}
 
-		server, err := NewServer(config)
+		server, err := NewServer(&config)
 		if err != nil {
 			t.Fatalf("NewServer() failed: %v", err)
 		}
@@ -339,7 +339,7 @@ func TestServerWithErrors(t *testing.T) {
 			FeedAndItemsGetter: mockFeedItems,
 		}
 
-		server, err := NewServer(config)
+		server, err := NewServer(&config)
 		if err != nil {
 			t.Fatalf("NewServer() failed: %v", err)
 		}
@@ -400,7 +400,7 @@ func TestServerTransportTypes(t *testing.T) {
 				FeedAndItemsGetter: &mockFeedAndItemsGetter{},
 			}
 
-			server, err := NewServer(config)
+			server, err := NewServer(&config)
 
 			if tt.valid {
 				if err != nil {
@@ -430,7 +430,7 @@ func BenchmarkNewServer(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := NewServer(config)
+		_, err := NewServer(&config)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/mcpserver/tools_test.go
+++ b/mcpserver/tools_test.go
@@ -174,7 +174,7 @@ func TestToolLogic(t *testing.T) {
 		FeedAndItemsGetter: mockFeedItems,
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("NewServer() failed: %v", err)
 	}
@@ -483,7 +483,7 @@ func TestTransportErrorHandling(t *testing.T) {
 		FeedAndItemsGetter: mockFeedItems,
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(&config)
 	if err != nil {
 		t.Fatalf("NewServer() failed: %v", err)
 	}
@@ -507,7 +507,7 @@ func TestTypeDefinitions(t *testing.T) {
 		serverType := reflect.TypeFor[Server]()
 
 		// Check that Server has the expected fields
-		expectedFields := []string{"allFeedsGetter", "feedAndItemsGetter", "dynamicFeedManager", "resourceManager", "sessionID", "transport", "imageCache", "imageCircuitBreakers", "imageCBMutex", "httpClient"}
+		expectedFields := []string{"allFeedsGetter", "feedAndItemsGetter", "dynamicFeedManager", "resourceManager", "sessionID", "transport", "imageCache", "imageCircuitBreakers", "imageCBMutex", "httpClient", "httpPort", "httpStateless", "httpSessionTimeout"}
 
 		if serverType.NumField() != len(expectedFields) {
 			t.Errorf("Expected %d fields in Server, got %d", len(expectedFields), serverType.NumField())
@@ -525,7 +525,7 @@ func TestTypeDefinitions(t *testing.T) {
 		configType := reflect.TypeFor[Config]()
 
 		// Check that Config has the expected fields
-		expectedFields := []string{"AllFeedsGetter", "FeedAndItemsGetter", "DynamicFeedManager", "Transport"}
+		expectedFields := []string{"AllFeedsGetter", "FeedAndItemsGetter", "DynamicFeedManager", "Transport", "HTTPPort", "HTTPStateless", "HTTPSessionTimeout"}
 
 		if configType.NumField() != len(expectedFields) {
 			t.Errorf("Expected %d fields in Config, got %d", len(expectedFields), configType.NumField())

--- a/model/features/transport_parsing.feature
+++ b/model/features/transport_parsing.feature
@@ -9,10 +9,16 @@ Feature: Transport Parsing
     Then the result should be StdioTransport
     And there should be no error
 
-  Scenario: Parsing HTTP with SSE transport
+  Scenario: Parsing HTTP with SSE transport (deprecated, maps to streamable-http)
     Given I have a transport string "http-with-sse"
     When I parse it using ParseTransport
-    Then the result should be HttpWithSSETransport
+    Then the result should be StreamableHTTPTransport
+    And there should be no error
+
+  Scenario: Parsing Streamable HTTP transport
+    Given I have a transport string "streamable-http"
+    When I parse it using ParseTransport
+    Then the result should be StreamableHTTPTransport
     And there should be no error
 
   Scenario: Parsing invalid transport string
@@ -34,10 +40,11 @@ Feature: Transport Parsing
     And the error state should be <has_error>
 
     Examples:
-      | input         | expected_transport    | has_error |
-      | stdio         | StdioTransport        | false     |
-      | http-with-sse | HttpWithSSETransport  | false     |
-      | invalid       | UndefinedTransport    | true      |
-      |               | UndefinedTransport    | true      |
-      | STDIO         | UndefinedTransport    | true      |
-      | http          | UndefinedTransport    | true      |
+      | input           | expected_transport      | has_error |
+      | stdio           | StdioTransport          | false     |
+      | http-with-sse   | StreamableHTTPTransport | false     |
+      | streamable-http | StreamableHTTPTransport | false     |
+      | invalid         | UndefinedTransport      | true      |
+      |                 | UndefinedTransport      | true      |
+      | STDIO           | UndefinedTransport      | true      |
+      | http            | UndefinedTransport      | true      |

--- a/model/feed_test.go
+++ b/model/feed_test.go
@@ -155,6 +155,13 @@ func (t *transportParsingTest) theResultShouldBeHTTPWithSSETransport() error {
 	return nil
 }
 
+func (t *transportParsingTest) theResultShouldBeStreamableHTTPTransport() error {
+	if t.outputTransport != StreamableHTTPTransport {
+		return fmt.Errorf("expected StreamableHTTPTransport, got %v", t.outputTransport)
+	}
+	return nil
+}
+
 func (t *transportParsingTest) theResultShouldBeUndefinedTransport() error {
 	if t.outputTransport != UndefinedTransport {
 		return fmt.Errorf("expected UndefinedTransport, got %v", t.outputTransport)
@@ -199,6 +206,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I parse it using ParseTransport$`, transportTest.iParseItUsingParseTransport)
 	ctx.Step(`^the result should be StdioTransport$`, transportTest.theResultShouldBeStdioTransport)
 	ctx.Step(`^the result should be HttpWithSSETransport$`, transportTest.theResultShouldBeHTTPWithSSETransport)
+	ctx.Step(`^the result should be StreamableHTTPTransport$`, transportTest.theResultShouldBeStreamableHTTPTransport)
 	ctx.Step(`^the result should be UndefinedTransport$`, transportTest.theResultShouldBeUndefinedTransport)
 	ctx.Step(`^there should be no error$`, transportTest.thereShouldBeNoError)
 	ctx.Step(`^there should be an error$`, transportTest.thereShouldBeAnError)

--- a/model/transport.go
+++ b/model/transport.go
@@ -14,7 +14,8 @@ type Transport uint8
 const (
 	UndefinedTransport Transport = iota
 	StdioTransport
-	HTTPWithSSETransport
+	HTTPWithSSETransport    // Deprecated: use StreamableHTTPTransport instead
+	StreamableHTTPTransport // Streamable HTTP transport per MCP spec
 )
 
 // ParseTransport converts a string to a Transport type
@@ -23,7 +24,10 @@ func ParseTransport(transport string) (Transport, error) {
 	case "stdio":
 		return StdioTransport, nil
 	case "http-with-sse":
-		return HTTPWithSSETransport, nil
+		// Deprecated: maps to StreamableHTTPTransport for backwards compatibility
+		return StreamableHTTPTransport, nil
+	case "streamable-http":
+		return StreamableHTTPTransport, nil
 	default:
 		return UndefinedTransport, ErrInvalidTransport
 	}
@@ -35,7 +39,9 @@ func (t Transport) String() string {
 	case StdioTransport:
 		return "stdio"
 	case HTTPWithSSETransport:
-		return "http-with-sse"
+		return "http-with-sse" // Deprecated
+	case StreamableHTTPTransport:
+		return "streamable-http"
 	default:
 		return "undefined"
 	}

--- a/model/transport_test.go
+++ b/model/transport_test.go
@@ -11,7 +11,8 @@ func TestParseTransport(t *testing.T) {
 		wantErr bool
 	}{
 		{"stdio", StdioTransport, false},
-		{"http-with-sse", HTTPWithSSETransport, false},
+		{"http-with-sse", StreamableHTTPTransport, false}, // Deprecated input, maps to StreamableHTTPTransport
+		{"streamable-http", StreamableHTTPTransport, false},
 		{"invalid", UndefinedTransport, true},
 		{"", UndefinedTransport, true},
 	}
@@ -32,7 +33,8 @@ func TestTransportString(t *testing.T) {
 		tr   Transport
 	}{
 		{"stdio", StdioTransport},
-		{"http-with-sse", HTTPWithSSETransport},
+		{"http-with-sse", HTTPWithSSETransport}, // Deprecated constant
+		{"streamable-http", StreamableHTTPTransport},
 		{"undefined", UndefinedTransport},
 		{"undefined", Transport(99)},
 	}


### PR DESCRIPTION
## Summary

- Replace deprecated SSE-based HTTP transport with Streamable HTTP transport using the official MCP Go SDK's `NewStreamableHTTPHandler`
- Add backwards compatibility: `http-with-sse` CLI option still works but maps to the new transport
- Add new CLI options: `--http-port` (default: 8080), `--http-stateless`, `--http-session-timeout`
- Add `ReadHeaderTimeout` to prevent Slowloris attacks
- Update documentation in CLAUDE.md

## Context

PR #118 implemented HTTP+SSE transport using the deprecated `SSEHandler`. This PR properly implements the current MCP specification using Streamable HTTP transport.

## Usage

```bash
# Recommended (Streamable HTTP)
go run main.go run --transport=streamable-http https://example.com/feed.xml

# With custom port
go run main.go run --transport=streamable-http --http-port=3000 https://example.com/feed.xml

# Backwards compatible (deprecated)
go run main.go run --transport=http-with-sse https://example.com/feed.xml
```

## Test plan

- [ ] Verify `make test` passes
- [ ] Verify `make lint` passes
- [ ] Test with `--transport=streamable-http` flag
- [ ] Test backwards compatibility with `--transport=http-with-sse`
- [ ] Verify HTTP server starts on correct port

Slack thread: https://spandigital.slack.com/archives/D0B4EF0AR1V/p1779219643502559?thread_ts=1779218631.662609&cid=D0B4EF0AR1V

https://claude.ai/code/session_01WGL1fm7zum2rb9zWmR5A5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGL1fm7zum2rb9zWmR5A5D)_