### PR TITLE
fix(mcpserver): route query-parameterized resource reads via template

### DIFF
--- a/mcpserver/resource_template_test.go
+++ b/mcpserver/resource_template_test.go
@@ -1,0 +1,161 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mmcdole/gofeed"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/feed-mcp/model"
+)
+
+// buildTestServerSession wires a fully-registered MCP server (tools, resources,
+// templates, prompts) to an in-memory transport and returns a connected client
+// session. This exercises the real SDK resources/read dispatch path, unlike
+// tests that call ResourceManager.ReadResource directly.
+func buildTestServerSession(t *testing.T, feedID, publicURL string, items []*gofeed.Item) *mcp.ClientSession {
+	t.Helper()
+
+	feedResult := &model.FeedResult{
+		ID:        feedID,
+		Title:     "Template Test Feed",
+		PublicURL: publicURL,
+		Feed: &model.Feed{
+			Title:    "Template Test Feed",
+			Link:     "https://example.com",
+			FeedType: "rss",
+		},
+	}
+	allFeeds := &mockResourceAllFeedsGetter{feeds: []*model.FeedResult{feedResult}}
+	feedGetter := &mockResourceFeedAndItemsGetter{feeds: map[string]*model.FeedAndItemsResult{
+		feedID: {
+			ID:        feedID,
+			PublicURL: publicURL,
+			Title:     "Template Test Feed",
+			Feed:      feedResult.Feed,
+			Items:     items,
+		},
+	}}
+
+	srv, err := NewServer(&Config{
+		Transport:          model.StdioTransport,
+		AllFeedsGetter:     allFeeds,
+		FeedAndItemsGetter: feedGetter,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mcpServer := srv.buildMCPServer()
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := mcpServer.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	return clientSession
+}
+
+func makeTestItems(n int) []*gofeed.Item {
+	items := make([]*gofeed.Item, 0, n)
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		pub := base.AddDate(0, 0, i)
+		items = append(items, &gofeed.Item{
+			Title:           "Item",
+			Link:            "https://example.com/item",
+			Published:       pub.Format(time.RFC3339),
+			PublishedParsed: &pub,
+		})
+	}
+	return items
+}
+
+// TestResourceReadWithQueryParams is a regression test for the bug where
+// resources/read of a templated URI carrying a query string (e.g.
+// feeds://feed/{id}/items?limit=3) returned "Resource not found" because the
+// server registered only concrete URIs and no resource template. The SDK
+// matches concrete URIs by exact string and then falls back to templates, so a
+// query string caused the read to fail before ReadResource was reached.
+func TestResourceReadWithQueryParams(t *testing.T) {
+	const publicURL = "https://example.com/feed.xml"
+	feedID := model.GenerateFeedID(publicURL)
+	cs := buildTestServerSession(t, feedID, publicURL, makeTestItems(10))
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		uri  string
+	}{
+		{"base feed", "feeds://feed/" + feedID},
+		{"items no query", "feeds://feed/" + feedID + "/items"},
+		{"meta", "feeds://feed/" + feedID + "/meta"},
+		{"items with limit", "feeds://feed/" + feedID + "/items?limit=3"},
+		{"items with multiple params", "feeds://feed/" + feedID + "/items?search=item&limit=2&offset=1"},
+		// RFC 3339 timestamp values contain ':' — only reserved-expansion
+		// template matching handles these.
+		{"items with rfc3339 since", "feeds://feed/" + feedID + "/items?since=2024-01-03T00:00:00Z"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: tc.uri})
+			if err != nil {
+				t.Fatalf("ReadResource(%q) returned error: %v", tc.uri, err)
+			}
+			if len(res.Contents) == 0 || res.Contents[0].Text == "" {
+				t.Fatalf("ReadResource(%q) returned empty content", tc.uri)
+			}
+		})
+	}
+}
+
+// TestResourceQueryFilterApplied verifies that query parameters are not merely
+// accepted but actually applied: a limit reduces the number of returned items.
+func TestResourceQueryFilterApplied(t *testing.T) {
+	const publicURL = "https://example.com/feed.xml"
+	feedID := model.GenerateFeedID(publicURL)
+	cs := buildTestServerSession(t, feedID, publicURL, makeTestItems(10))
+	ctx := context.Background()
+
+	countItems := func(uri string) int {
+		res, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+		if err != nil {
+			t.Fatalf("ReadResource(%q): %v", uri, err)
+		}
+		if len(res.Contents) == 0 {
+			t.Fatalf("ReadResource(%q): no contents", uri)
+		}
+		// The items resource returns a single JSON object {items, count, ...}.
+		var payload struct {
+			Count int `json:"count"`
+		}
+		if err := json.Unmarshal([]byte(res.Contents[0].Text), &payload); err != nil {
+			t.Fatalf("ReadResource(%q): unmarshal: %v", uri, err)
+		}
+		return payload.Count
+	}
+
+	all := countItems("feeds://feed/" + feedID + "/items")
+	limited := countItems("feeds://feed/" + feedID + "/items?limit=3")
+
+	if limited >= all {
+		t.Errorf("expected limit=3 to return fewer entries than unfiltered (all=%d, limited=%d)", all, limited)
+	}
+	if limited == 0 {
+		t.Errorf("expected limit=3 to return some entries, got 0")
+	}
+}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -217,14 +217,22 @@ type MergedFeedResult struct {
 
 // Run starts the MCP server and handles client connections until context is canceled
 func (s *Server) Run(ctx context.Context) (err error) {
+	srv := s.buildMCPServer()
+	return s.runTransport(ctx, srv)
+}
+
+// buildMCPServer creates the MCP server and registers all tools, resources,
+// and prompts. It is separated from Run so tests can exercise the fully wired
+// server over an in-memory transport (rather than only calling handlers
+// directly, which bypasses the SDK's resources/read dispatch and URI matching).
+func (s *Server) buildMCPServer() *mcp.Server {
 	srv := s.createMCPServer()
 	s.registerCoreTools(srv)
 	s.addAggregationTools(srv)
 	s.addDynamicFeedTools(srv)
 	s.addResourceHandlers(srv)
 	s.addPrompts(srv)
-
-	return s.runTransport(ctx, srv)
+	return srv
 }
 
 // createMCPServer creates and configures the MCP server instance
@@ -868,6 +876,27 @@ func (s *Server) addResourceHandlers(srv *mcp.Server) {
 			return s.resourceManager.ReadResource(ctx, req.Params.URI)
 		})
 	}
+
+	// Register a resource template so templated and query-parameterized reads
+	// (e.g. feeds://feed/{id}/items?limit=10&since=2024-01-01T00:00:00Z) are
+	// routed to ReadResource. resources/read is matched first against the
+	// concrete URIs registered above (exact match), then against resource
+	// templates; without a template, any URI carrying a query string fails with
+	// "Resource not found" before ReadResource — and its filter handling — is
+	// ever reached. A single reserved-expansion template ({+path}) matches every
+	// feeds://feed/... URI, including query values containing reserved characters
+	// such as the ':' in RFC 3339 timestamps, which the standard {?query} form
+	// cannot match. ReadResource dispatches to the correct handler by path.
+	feedTemplate := &mcp.ResourceTemplate{
+		Name:        "feed",
+		Title:       "Feed, items, or metadata (with filters)",
+		Description: "Read a feed (feeds://feed/{id}), its items (feeds://feed/{id}/items), or its metadata (feeds://feed/{id}/meta). The items resource supports query filters: since, until, limit, offset, category, author, search.",
+		MIMEType:    JSONMIMEType,
+		URITemplate: "feeds://feed/{+path}",
+	}
+	srv.AddResourceTemplate(feedTemplate, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return s.resourceManager.ReadResource(ctx, req.Params.URI)
+	})
 }
 
 // Resource operations are handled automatically by the MCP SDK v0.3.0


### PR DESCRIPTION
## Problem

Resource reads carrying a **query string** fail with `Resource not found`:

```
feeds://feed/{id}/items?limit=10
feeds://feed/{id}/items?since=2024-01-01T00:00:00Z&category=tech
```

Found while comprehensively testing the server end-to-end against real RSS/Atom/JSON feeds (BBC, Hacker News, The Go Blog, GitHub releases, Daring Fireball, Flying Meat) over a real MCP client. Base resources (`feeds://all`, `feeds://feed/{id}`, `.../items`, `.../meta`) all read fine — **only query-parameterized reads failed**.

## Root cause

Resources were registered only as **concrete URIs** via `srv.AddResource(...)`. The SDK's `resources/read` dispatch (`lookupResourceHandler`) matches first by **exact URI**, then falls back to registered **resource templates**. With no template registered, any URI with a query string matched nothing and was rejected *before* `ReadResource` — and its already-implemented filter handling (`since`/`until`/`limit`/`offset`/`category`/`author`/`search`) — was ever reached.

This went unnoticed because the existing tests call `ResourceManager.ReadResource` **directly**, bypassing the SDK dispatch layer where the failure occurs.

## Fix

Register a reserved-expansion resource template `feeds://feed/{+path}` that matches every `feeds://feed/...` URI, including query values containing reserved characters such as the `:` in RFC 3339 timestamps. (The standard `{?query}` form can't match colons — its char class excludes them.) `ReadResource` continues to dispatch to the correct handler by path.

## Tests

- Extracted `buildMCPServer()` from `Run()` so tests can drive the fully wired server over an **in-memory transport** — the real SDK dispatch path.
- Added `TestResourceReadWithQueryParams` (base/items/meta + `?limit`, multi-param, and RFC 3339 `?since` with colons) and `TestResourceQueryFilterApplied` (verifies a `limit` actually reduces returned items).
- Confirmed the new tests **fail without the fix** (`Resource not found` on query URIs, no-query cases still pass) and **pass with it**.

## Verification

- `go test ./...` — all pass.
- golangci-lint **v2.9.0** (CI-pinned) — `0 issues`.
- End-to-end against the live Daring Fireball JSON feed via the real binary:
  - `.../items` → 48 items
  - `.../items?limit=3` → 3
  - `.../items?search=apple&limit=5` → 5
  - `.../items?since=2020-01-01T00:00:00Z&limit=4` → 4
  - `resources/templates/list` now advertises `feeds://feed/{+path}`.

> Note: a separate doc nit was also found — `CLAUDE.md` references `feeds://list` and `/metadata` while the implementation uses `feeds://all` and `/meta`. Left out of this PR because `CLAUDE.md` currently has unrelated uncommitted edits in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)