### PR TITLE
refactor: modernize with go fix and slices/cmp helpers

### DIFF
--- a/cmd/cmd_opml_test.go
+++ b/cmd/cmd_opml_test.go
@@ -309,8 +309,8 @@ func BenchmarkRunCmd_OPML_Parsing(b *testing.B) {
 	<body>`)
 
 	for i := range 100 {
-		opmlContent.WriteString(fmt.Sprintf(`
-		<outline text="Feed %d" xmlUrl="https://example%d.com/feed.xml" />`, i, i))
+		fmt.Fprintf(&opmlContent, `
+		<outline text="Feed %d" xmlUrl="https://example%d.com/feed.xml" />`, i, i)
 	}
 
 	opmlContent.WriteString(`

--- a/mcpserver/pagination_test.go
+++ b/mcpserver/pagination_test.go
@@ -11,10 +11,7 @@ func applyPaginationParams(totalItems int, limit *int, offset *int) (returnedIte
 	// Apply limit
 	effectiveLimit := DefaultItemLimit
 	if limit != nil {
-		effectiveLimit = min(*limit, MaxItemLimit)
-		if effectiveLimit < 0 {
-			effectiveLimit = 0
-		}
+		effectiveLimit = max(min(*limit, MaxItemLimit), 0)
 	}
 
 	// Apply offset

--- a/mcpserver/prompts.go
+++ b/mcpserver/prompts.go
@@ -1,10 +1,11 @@
 package mcpserver
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"hash/fnv"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -767,8 +768,8 @@ func formatCoverageAnalysis(comparison *sourceComparison) string {
 		sorted = append(sorted, sourceCoverage{source, cov})
 	}
 
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].coverage > sorted[j].coverage
+	slices.SortFunc(sorted, func(a, b sourceCoverage) int {
+		return cmp.Compare(b.coverage, a.coverage)
 	})
 
 	for _, sc := range sorted {
@@ -1096,7 +1097,7 @@ func generateErrorAnalysis(feeds []*model.FeedResult) string {
 	var analysis strings.Builder
 	analysis.WriteString("**Error Breakdown:**\n")
 	for errorType, count := range errorTypes {
-		analysis.WriteString(fmt.Sprintf("- %s: %d occurrences\n", errorType, count))
+		fmt.Fprintf(&analysis, "- %s: %d occurrences\n", errorType, count)
 	}
 
 	analysis.WriteString("\n**Failed Feeds:**\n" + strings.Join(errorFeeds, "\n"))

--- a/mcpserver/resource_template_test.go
+++ b/mcpserver/resource_template_test.go
@@ -72,7 +72,7 @@ func buildTestServerSession(t *testing.T, feedID, publicURL string, items []*gof
 func makeTestItems(n int) []*gofeed.Item {
 	items := make([]*gofeed.Item, 0, n)
 	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		pub := base.AddDate(0, 0, i)
 		items = append(items, &gofeed.Item{
 			Title:           "Item",

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -2,6 +2,7 @@
 package mcpserver
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -10,7 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -389,10 +390,7 @@ func (s *Server) parsePaginationParams(args GetSyndicationFeedParams) ParsedFeed
 
 	// Parse limit
 	if args.Limit != nil {
-		params.Limit = min(*args.Limit, MaxItemLimit)
-		if params.Limit < 0 {
-			params.Limit = 0
-		}
+		params.Limit = max(min(*args.Limit, MaxItemLimit), 0)
 	}
 
 	// Parse offset
@@ -1544,27 +1542,34 @@ func deduplicateItems(items []*gofeed.Item) []*gofeed.Item {
 
 // sortItemsByDate sorts items by published date (newest first)
 func sortItemsByDate(items []*gofeed.Item) {
-	sort.Slice(items, func(i, j int) bool {
-		// Handle nil PublishedParsed dates
-		if items[i].PublishedParsed == nil || items[j].PublishedParsed == nil {
-			return items[i].PublishedParsed != nil
+	slices.SortFunc(items, func(a, b *gofeed.Item) int {
+		// Handle nil PublishedParsed dates: non-nil sorts before nil
+		if a.PublishedParsed == nil || b.PublishedParsed == nil {
+			switch {
+			case a.PublishedParsed != nil:
+				return -1
+			case b.PublishedParsed != nil:
+				return 1
+			default:
+				return 0
+			}
 		}
-		// Sort newest first (i > j means i is newer)
-		return items[i].PublishedParsed.After(*items[j].PublishedParsed)
+		// Sort newest first
+		return b.PublishedParsed.Compare(*a.PublishedParsed)
 	})
 }
 
 // sortItemsByTitle sorts items alphabetically by title
 func sortItemsByTitle(items []*gofeed.Item) {
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].Title < items[j].Title
+	slices.SortFunc(items, func(a, b *gofeed.Item) int {
+		return cmp.Compare(a.Title, b.Title)
 	})
 }
 
 // sortItemsBySource sorts items by source feed title
 func sortItemsBySource(items []*gofeed.Item) {
-	sort.Slice(items, func(i, j int) bool {
-		return getItemSource(items[i]) < getItemSource(items[j])
+	slices.SortFunc(items, func(a, b *gofeed.Item) int {
+		return cmp.Compare(getItemSource(a), getItemSource(b))
 	})
 }
 
@@ -1682,8 +1687,8 @@ func exportAsCSV(feedResults []*FeedAndItemsResult) (string, error) {
 			}
 			description := escapeCSVField(item.Description)
 
-			result.WriteString(fmt.Sprintf("%s,%s,%s,%s,%s,%s\n",
-				feedTitle, feedURL, itemTitle, itemLink, publishedDate, description))
+			fmt.Fprintf(&result, "%s,%s,%s,%s,%s,%s\n",
+				feedTitle, feedURL, itemTitle, itemLink, publishedDate, description)
 		}
 	}
 
@@ -1703,8 +1708,8 @@ func exportAsOPML(feedResults []*FeedAndItemsResult) (string, error) {
 `)
 
 	for _, feedResult := range feedResults {
-		result.WriteString(fmt.Sprintf(`<outline text=%q title=%q type="rss" xmlUrl=%q htmlUrl=%q/>`,
-			escapeXML(feedResult.Title), escapeXML(feedResult.Title), escapeXML(feedResult.PublicURL), escapeXML(feedResult.PublicURL)))
+		fmt.Fprintf(&result, `<outline text=%q title=%q type="rss" xmlUrl=%q htmlUrl=%q/>`,
+			escapeXML(feedResult.Title), escapeXML(feedResult.Title), escapeXML(feedResult.PublicURL), escapeXML(feedResult.PublicURL))
 		result.WriteString("\n")
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1615,7 +1615,7 @@ func TestRateLimitedTransport_PerHost(t *testing.T) {
 			done <- err
 		}(host)
 	}
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-done; err != nil {
 			t.Fatalf("RoundTrip failed: %v", err)
 		}
@@ -1640,7 +1640,7 @@ func TestRateLimitedTransport_SameHostStillLimited(t *testing.T) {
 	}
 
 	start := time.Now()
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		resp, err := rt.RoundTrip(newTestRequest(t, "host-c.example"))
 		if err != nil {
 			t.Fatalf("RoundTrip %d failed: %v", i, err)


### PR DESCRIPTION
Modernizes the codebase using Go 1.26's analysis-based [`go fix`](https://go.dev/blog/gofix) plus a few hand modernizations `go fix` intentionally leaves.

## Changes
- **`go fix` modernizers** (auto-applied):
  - min/max clamp simplification (`if x<0 {x=0}` → `max(min(...), 0)`) in `server.go`, `pagination_test.go`.
  - `for i := 0; i < N; i++` → `for range N` in `resource_template_test.go`, `store_test.go`.
- **`sort.Slice` → `slices.SortFunc`** (custom comparators, so `go fix` skips them) using `cmp.Compare`: item sorters by date/title/source (`server.go`) and the coverage sorter (`prompts.go`). Drops the `sort` import for `slices`/`cmp`.
- **`WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(builder, ...)`** in the CSV/OPML exporters (`server.go`), error analysis (`prompts.go`), and an OPML test helper (`cmd_opml_test.go`) — avoids an intermediate string allocation.

No behavior change.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- golangci-lint **v2.9.0** (current CI pin) — `0 issues`.

> Part 1 of a two-PR tooling modernization. Part 2 bumps golangci-lint to v2.12.2 and handles the additional findings it surfaces (goconst, gosec G115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)