### PR TITLE
chore: upgrade golangci-lint to v2.12.2 and resolve new findings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9.2.0
       with:
-        version: v2.9.0
+        version: v2.12.2
 
     - name: Update coverage report
       uses: ncruces/go-coverage-report@v0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,6 +123,7 @@ linters:
           - dupl
           - gosec
           - gocritic
+          - goconst # tests legitimately repeat literal fixtures
       
       # Exclude shadow warnings for short variable names
       - linters:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 # Variables
 BINARY_NAME := feed-mcp
-GOLANGCI_LINT_VERSION := v2.9.0
+GOLANGCI_LINT_VERSION := v2.12.2
 GOPATH := $(shell go env GOPATH)
 GOLANGCI_LINT := $(GOPATH)/bin/golangci-lint
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/richardwooding/feed-mcp
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/cucumber/godog v0.15.1

--- a/mcpserver/constants.go
+++ b/mcpserver/constants.go
@@ -1,0 +1,90 @@
+package mcpserver
+
+// Shared string constants for the mcpserver package.
+//
+// These extract repeated string literals (JSON-schema keys, schema type
+// values, schema documentation/format strings, tool names, and other
+// recurring values) into named constants. Values are byte-for-byte identical
+// to the literals they replace; changing any value would alter the server's
+// JSON-schema, tool, prompt, or resource output.
+
+// JSON/schema object keys.
+const (
+	keyDescription = "description"
+	keyFormat      = "format"
+	keyRequired    = "required"
+	keyExample     = "example"
+	keyTitle       = "title"
+	keyUpdatedAt   = "updated_at"
+	keyValues      = "values"
+	keyRange       = "range"
+	keyDefault     = "default"
+	keyURI         = "uri"
+	keyFeedID      = "feedId"
+	keyFeedIDs     = "feedIds"
+	keyID          = "ID"
+	keyURL         = "URL"
+	keyURLLower    = "url"
+	keyItemIndex   = "itemIndex"
+	keyTimeframe   = "timeframe"
+)
+
+// JSON-schema type values.
+const (
+	typeObject  = "object"
+	typeString  = "string"
+	typeInteger = "integer"
+	typeBoolean = "boolean"
+)
+
+// Schema documentation/format value strings.
+const (
+	formatInteger      = "Integer"
+	formatStringDoc    = "String"
+	docTextString      = "Text string"
+	docNonNegativeInts = "0 or positive integers"
+)
+
+// Tool names.
+const (
+	toolFetchLink               = "fetch_link"
+	toolAllSyndicationFeeds     = "all_syndication_feeds"
+	toolGetSyndicationFeedItems = "get_syndication_feed_items"
+)
+
+// Sentiment, sort, and format enum/value strings shared across resources,
+// filters, and tool schemas.
+const (
+	sentimentPositive = "positive"
+	sentimentNegative = "negative"
+	sentimentNeutral  = "neutral"
+
+	sortByDate       = "date"
+	sortByRelevance  = "relevance"
+	sortByPopularity = "popularity"
+	valueSource      = "source"
+
+	formatJSON     = "json"
+	formatXML      = "xml"
+	formatHTML     = "html"
+	formatMarkdown = "markdown"
+	formatCSV      = "csv"
+	formatOPML     = "opml"
+	formatRSS      = "rss"
+	formatAtom     = "atom"
+)
+
+// Prompt-related values.
+const (
+	roleUser     = "user"
+	timeframe24h = "24h"
+	timeframe7d  = "7d"
+)
+
+// Miscellaneous shared strings.
+const (
+	serverName           = "RSS, Atom, and JSON Feed Server"
+	fetchLinkDescription = "Fetch link URL"
+	linkURLDescription   = "Link URL"
+	nameAllFeeds         = "All Feeds"
+)

--- a/mcpserver/dynamicfeedmanager.go
+++ b/mcpserver/dynamicfeedmanager.go
@@ -84,7 +84,7 @@ type FeedSource string
 
 // Feed source constants indicate how a feed was added to the system
 const (
-	FeedSourceStartup FeedSource = "startup" // From CLI args
-	FeedSourceOPML    FeedSource = "opml"    // From OPML file
-	FeedSourceRuntime FeedSource = "runtime" // Added via tools
+	FeedSourceStartup FeedSource = "startup"  // From CLI args
+	FeedSourceOPML    FeedSource = formatOPML // From OPML file
+	FeedSourceRuntime FeedSource = "runtime"  // Added via tools
 )

--- a/mcpserver/prompts.go
+++ b/mcpserver/prompts.go
@@ -73,7 +73,7 @@ func (s *Server) getFeedsForPrompt(ctx context.Context, feedIDs string) ([]*mode
 // handleAnalyzeFeedTrends analyzes trends and patterns across multiple feeds
 func (s *Server) handleAnalyzeFeedTrends(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	// Parse arguments
-	timeframe := getStringArg(req.Params.Arguments, "timeframe", "24h")
+	timeframe := getStringArg(req.Params.Arguments, keyTimeframe, timeframe24h)
 	categories := getStringArg(req.Params.Arguments, "categories", "")
 
 	// Parse timeframe
@@ -144,7 +144,7 @@ Use this analysis to understand content trends, optimize feed monitoring, and id
 		Description: "Feed trend analysis with insights and patterns",
 		Messages: []*mcp.PromptMessage{
 			{
-				Role: "user",
+				Role: roleUser,
 				Content: &mcp.TextContent{
 					Text: promptContent,
 				},
@@ -189,7 +189,7 @@ func (s *Server) handleSummarizeFeeds(ctx context.Context, req *mcp.GetPromptReq
 		Description: fmt.Sprintf("Feed content summary (%s)", summaryType),
 		Messages: []*mcp.PromptMessage{
 			{
-				Role: "user",
+				Role: roleUser,
 				Content: &mcp.TextContent{
 					Text: promptContent,
 				},
@@ -205,7 +205,7 @@ func (s *Server) handleMonitorKeywords(ctx context.Context, req *mcp.GetPromptRe
 		return createErrorPromptResult("Keywords parameter is required"), nil
 	}
 
-	timeframe := getStringArg(req.Params.Arguments, "timeframe", "24h")
+	timeframe := getStringArg(req.Params.Arguments, keyTimeframe, timeframe24h)
 	alertThreshold := getIntArg(req.Params.Arguments, "alert_threshold", 1)
 
 	// Parse keywords
@@ -264,7 +264,7 @@ func (s *Server) handleMonitorKeywords(ctx context.Context, req *mcp.GetPromptRe
 		Description: fmt.Sprintf("Keyword monitoring report for: %s", keywords),
 		Messages: []*mcp.PromptMessage{
 			{
-				Role: "user",
+				Role: roleUser,
 				Content: &mcp.TextContent{
 					Text: promptContent,
 				},
@@ -325,7 +325,7 @@ func (s *Server) handleCompareSources(ctx context.Context, req *mcp.GetPromptReq
 		Description: fmt.Sprintf("Source comparison for topic: %s", topic),
 		Messages: []*mcp.PromptMessage{
 			{
-				Role: "user",
+				Role: roleUser,
 				Content: &mcp.TextContent{
 					Text: promptContent,
 				},
@@ -337,7 +337,7 @@ func (s *Server) handleCompareSources(ctx context.Context, req *mcp.GetPromptReq
 // handleGenerateFeedReport generates detailed feed reports
 func (s *Server) handleGenerateFeedReport(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	reportType := getStringArg(req.Params.Arguments, "report_type", "comprehensive")
-	timeframe := getStringArg(req.Params.Arguments, "timeframe", "7d")
+	timeframe := getStringArg(req.Params.Arguments, keyTimeframe, timeframe7d)
 
 	// Parse timeframe
 	duration, err := parseDuration(timeframe)
@@ -377,7 +377,7 @@ func (s *Server) handleGenerateFeedReport(ctx context.Context, req *mcp.GetPromp
 		Description: fmt.Sprintf("Feed %s report", reportType),
 		Messages: []*mcp.PromptMessage{
 			{
-				Role: "user",
+				Role: roleUser,
 				Content: &mcp.TextContent{
 					Text: promptContent,
 				},
@@ -393,7 +393,7 @@ func createErrorPromptResult(errorMsg string) *mcp.GetPromptResult {
 		Description: "Error in prompt execution",
 		Messages: []*mcp.PromptMessage{
 			{
-				Role: "user",
+				Role: roleUser,
 				Content: &mcp.TextContent{
 					Text: fmt.Sprintf("Error: %s\n\nPlease check your parameters and try again.", errorMsg),
 				},
@@ -423,9 +423,9 @@ func parseDuration(timeframe string) (time.Duration, error) {
 	switch strings.ToLower(timeframe) {
 	case "1h", "hour":
 		return time.Hour, nil
-	case "24h", "day", "1d":
+	case timeframe24h, "day", "1d":
 		return 24 * time.Hour, nil
-	case "7d", "week", "1w":
+	case timeframe7d, "week", "1w":
 		return 7 * 24 * time.Hour, nil
 	case "30d", "month", "1m":
 		return 30 * 24 * time.Hour, nil

--- a/mcpserver/resource_filters.go
+++ b/mcpserver/resource_filters.go
@@ -192,24 +192,24 @@ func parseEnhancedStringParams(query url.Values, params *FilterParams) {
 		params.SortBy = sortBy
 	}
 
-	if format := query.Get("format"); isValidFormat(format) {
+	if format := query.Get(keyFormat); isValidFormat(format) {
 		params.Format = format
 	}
 }
 
 // isValidSentiment checks if sentiment value is valid
 func isValidSentiment(sentiment string) bool {
-	return sentiment == "positive" || sentiment == "negative" || sentiment == "neutral"
+	return sentiment == sentimentPositive || sentiment == sentimentNegative || sentiment == sentimentNeutral
 }
 
 // isValidSortBy checks if sort_by value is valid
 func isValidSortBy(sortBy string) bool {
-	return sortBy == "date" || sortBy == "relevance" || sortBy == "popularity"
+	return sortBy == sortByDate || sortBy == sortByRelevance || sortBy == sortByPopularity
 }
 
 // isValidFormat checks if format value is valid
 func isValidFormat(format string) bool {
-	return format == "json" || format == "xml" || format == "html" || format == "markdown"
+	return format == formatJSON || format == formatXML || format == formatHTML || format == formatMarkdown
 }
 
 // parseBooleanParameters handles has_media and duplicates parameter parsing
@@ -540,7 +540,7 @@ func addEnhancedFiltersToMap(appliedFilters map[string]any, filters *FilterParam
 		appliedFilters["sort_by"] = filters.SortBy
 	}
 	if filters.Format != "" {
-		appliedFilters["format"] = filters.Format
+		appliedFilters[keyFormat] = filters.Format
 	}
 }
 
@@ -676,7 +676,7 @@ func matchesSentiment(item *gofeed.Item, sentiment string) bool {
 	content := strings.ToLower(item.Title + " " + item.Description + " " + item.Content)
 
 	switch sentiment {
-	case "positive":
+	case sentimentPositive:
 		positiveWords := []string{
 			"good", "great", "excellent", "amazing", "wonderful", "fantastic",
 			"success", "win", "love", "best", "awesome", "brilliant",
@@ -690,7 +690,7 @@ func matchesSentiment(item *gofeed.Item, sentiment string) bool {
 		}
 		return positiveCount >= 2
 
-	case "negative":
+	case sentimentNegative:
 		negativeWords := []string{
 			"bad", "terrible", "awful", "horrible", "worst", "hate",
 			"fail", "failure", "problem", "issue", "crisis", "disaster",
@@ -704,10 +704,10 @@ func matchesSentiment(item *gofeed.Item, sentiment string) bool {
 		}
 		return negativeCount >= 2
 
-	case "neutral":
+	case sentimentNeutral:
 		// Neutral is default if not clearly positive or negative
 		// Check for absence of strong sentiment indicators
-		return !matchesSentiment(item, "positive") && !matchesSentiment(item, "negative")
+		return !matchesSentiment(item, sentimentPositive) && !matchesSentiment(item, sentimentNegative)
 
 	default:
 		return false

--- a/mcpserver/resources.go
+++ b/mcpserver/resources.go
@@ -202,7 +202,7 @@ func (rm *ResourceManager) ListResources(ctx context.Context) ([]*mcp.Resource, 
 	resources = append(resources,
 		&mcp.Resource{
 			URI:         FeedListURI,
-			Name:        "All Feeds",
+			Name:        nameAllFeeds,
 			Description: "List of all available syndication feeds",
 			MIMEType:    JSONMIMEType,
 		},
@@ -229,19 +229,19 @@ func (rm *ResourceManager) ListResources(ctx context.Context) ([]*mcp.Resource, 
 		// Add all three feed resources at once
 		resources = append(resources,
 			&mcp.Resource{
-				URI:         expandURITemplate(FeedURI, map[string]string{"feedId": feedID}),
+				URI:         expandURITemplate(FeedURI, map[string]string{keyFeedID: feedID}),
 				Name:        fmt.Sprintf("Feed: %s", feed.Title),
 				Description: fmt.Sprintf("Complete feed data for %s. %s", feed.Title, ParameterDocsSummary),
 				MIMEType:    JSONMIMEType,
 			},
 			&mcp.Resource{
-				URI:         expandURITemplate(FeedItemsURI, map[string]string{"feedId": feedID}),
+				URI:         expandURITemplate(FeedItemsURI, map[string]string{keyFeedID: feedID}),
 				Name:        fmt.Sprintf("Items: %s", feed.Title),
 				Description: fmt.Sprintf("Feed items only for %s. %s", feed.Title, ParameterDocsSummary),
 				MIMEType:    JSONMIMEType,
 			},
 			&mcp.Resource{
-				URI:         expandURITemplate(FeedMetaURI, map[string]string{"feedId": feedID}),
+				URI:         expandURITemplate(FeedMetaURI, map[string]string{keyFeedID: feedID}),
 				Name:        fmt.Sprintf("Metadata: %s", feed.Title),
 				Description: fmt.Sprintf("Feed metadata for %s", feed.Title),
 				MIMEType:    JSONMIMEType,
@@ -303,7 +303,7 @@ func (rm *ResourceManager) readFeedList(ctx context.Context) (*mcp.ReadResourceR
 		feedID := model.GenerateFeedID(feed.PublicURL)
 		feedList = append(feedList, map[string]any{
 			"id":                   feedID,
-			"title":                feed.Title,
+			keyTitle:               feed.Title,
 			"public_url":           feed.PublicURL,
 			"has_error":            feed.FetchError != "",
 			"circuit_breaker_open": feed.CircuitBreakerOpen,
@@ -313,7 +313,7 @@ func (rm *ResourceManager) readFeedList(ctx context.Context) (*mcp.ReadResourceR
 	content := map[string]any{
 		"feeds":      feedList,
 		"count":      len(feedList),
-		"updated_at": time.Now().UTC(),
+		keyUpdatedAt: time.Now().UTC(),
 	}
 
 	contentJSON, err := marshalJSONContent(content, FeedListURI)
@@ -341,126 +341,126 @@ func (rm *ResourceManager) readParameterDocs(ctx context.Context) (*mcp.ReadReso
 	// Create comprehensive parameter documentation
 	parameterDocs := map[string]any{
 		"uri_parameters": map[string]any{
-			"description": "Complete documentation for URI parameters supported by feed resources",
+			keyDescription: "Complete documentation for URI parameters supported by feed resources",
 			"base_parameters": map[string]any{
 				"since": map[string]any{
-					"description": "Filter items published after this date",
-					"format":      "ISO 8601 datetime (e.g., 2023-01-01T00:00:00Z)",
-					"required":    false,
-					"example":     "since=2023-01-01T00:00:00Z",
+					keyDescription: "Filter items published after this date",
+					keyFormat:      "ISO 8601 datetime (e.g., 2023-01-01T00:00:00Z)",
+					keyRequired:    false,
+					keyExample:     "since=2023-01-01T00:00:00Z",
 				},
 				"until": map[string]any{
-					"description": "Filter items published before this date",
-					"format":      "ISO 8601 datetime (e.g., 2023-12-31T23:59:59Z)",
-					"required":    false,
-					"example":     "until=2023-12-31T23:59:59Z",
+					keyDescription: "Filter items published before this date",
+					keyFormat:      "ISO 8601 datetime (e.g., 2023-12-31T23:59:59Z)",
+					keyRequired:    false,
+					keyExample:     "until=2023-12-31T23:59:59Z",
 				},
 				"limit": map[string]any{
-					"description": "Maximum number of items to return",
-					"format":      "Integer",
-					"range":       "0-1000 (0 means no limit, values >1000 are capped)",
-					"required":    false,
-					"example":     "limit=10",
+					keyDescription: "Maximum number of items to return",
+					keyFormat:      formatInteger,
+					keyRange:       "0-1000 (0 means no limit, values >1000 are capped)",
+					keyRequired:    false,
+					keyExample:     "limit=10",
 				},
 				"offset": map[string]any{
-					"description": "Number of items to skip (for pagination)",
-					"format":      "Integer",
-					"range":       "0 or positive integers",
-					"required":    false,
-					"example":     "offset=20",
+					keyDescription: "Number of items to skip (for pagination)",
+					keyFormat:      formatInteger,
+					keyRange:       docNonNegativeInts,
+					keyRequired:    false,
+					keyExample:     "offset=20",
 				},
 				"category": map[string]any{
-					"description": "Filter items by category or tag (case-insensitive)",
-					"format":      "Text string",
-					"required":    false,
-					"example":     "category=technology",
+					keyDescription: "Filter items by category or tag (case-insensitive)",
+					keyFormat:      docTextString,
+					keyRequired:    false,
+					keyExample:     "category=technology",
 				},
 				"author": map[string]any{
-					"description": "Filter items by author name (case-insensitive)",
-					"format":      "Text string",
-					"required":    false,
-					"example":     "author=john%20smith",
+					keyDescription: "Filter items by author name (case-insensitive)",
+					keyFormat:      docTextString,
+					keyRequired:    false,
+					keyExample:     "author=john%20smith",
 				},
 				"search": map[string]any{
-					"description": "Full-text search across title, description, and content (case-insensitive)",
-					"format":      "Text string",
-					"required":    false,
-					"example":     "search=golang%20programming",
+					keyDescription: "Full-text search across title, description, and content (case-insensitive)",
+					keyFormat:      docTextString,
+					keyRequired:    false,
+					keyExample:     "search=golang%20programming",
 				},
 			},
 			"enhanced_parameters": map[string]any{
 				"language": map[string]any{
-					"description": "Filter items by language",
-					"format":      "ISO 639-1 language code",
-					"examples":    []string{"en", "es", "fr", "de", "ja", "zh"},
-					"required":    false,
-					"example":     "language=en",
+					keyDescription: "Filter items by language",
+					keyFormat:      "ISO 639-1 language code",
+					"examples":     []string{"en", "es", "fr", "de", "ja", "zh"},
+					keyRequired:    false,
+					keyExample:     "language=en",
 				},
 				"min_length": map[string]any{
-					"description": "Minimum content length in characters",
-					"format":      "Integer",
-					"range":       "0 or positive integers",
-					"required":    false,
-					"example":     "min_length=100",
+					keyDescription: "Minimum content length in characters",
+					keyFormat:      formatInteger,
+					keyRange:       docNonNegativeInts,
+					keyRequired:    false,
+					keyExample:     "min_length=100",
 				},
 				"max_length": map[string]any{
-					"description": "Maximum content length in characters",
-					"format":      "Integer",
-					"range":       "0 or positive integers",
-					"required":    false,
-					"example":     "max_length=5000",
+					keyDescription: "Maximum content length in characters",
+					keyFormat:      formatInteger,
+					keyRange:       docNonNegativeInts,
+					keyRequired:    false,
+					keyExample:     "max_length=5000",
 				},
 				"has_media": map[string]any{
-					"description": "Filter items that contain media (images, videos)",
-					"format":      "Boolean",
-					"values":      []string{"true", "false"},
-					"required":    false,
-					"example":     "has_media=true",
+					keyDescription: "Filter items that contain media (images, videos)",
+					keyFormat:      "Boolean",
+					keyValues:      []string{"true", "false"},
+					keyRequired:    false,
+					keyExample:     "has_media=true",
 				},
 				"sentiment": map[string]any{
-					"description": "Filter items by sentiment analysis result",
-					"format":      "String",
-					"values":      []string{"positive", "negative", "neutral"},
-					"required":    false,
-					"example":     "sentiment=positive",
+					keyDescription: "Filter items by sentiment analysis result",
+					keyFormat:      formatStringDoc,
+					keyValues:      []string{sentimentPositive, sentimentNegative, sentimentNeutral},
+					keyRequired:    false,
+					keyExample:     "sentiment=positive",
 				},
 				"duplicates": map[string]any{
-					"description": "Include or exclude duplicate content",
-					"format":      "Boolean",
-					"values":      []string{"true", "false"},
-					"default":     "true (include duplicates)",
-					"required":    false,
-					"example":     "duplicates=false",
+					keyDescription: "Include or exclude duplicate content",
+					keyFormat:      "Boolean",
+					keyValues:      []string{"true", "false"},
+					keyDefault:     "true (include duplicates)",
+					keyRequired:    false,
+					keyExample:     "duplicates=false",
 				},
 				"sort_by": map[string]any{
-					"description": "Sort order for results",
-					"format":      "String",
-					"values":      []string{"date", "relevance", "popularity"},
-					"default":     "date (newest first)",
-					"required":    false,
-					"example":     "sort_by=relevance",
+					keyDescription: "Sort order for results",
+					keyFormat:      formatStringDoc,
+					keyValues:      []string{sortByDate, sortByRelevance, sortByPopularity},
+					keyDefault:     "date (newest first)",
+					keyRequired:    false,
+					keyExample:     "sort_by=relevance",
 				},
-				"format": map[string]any{
-					"description": "Output format preference",
-					"format":      "String",
-					"values":      []string{"json", "xml", "html", "markdown"},
-					"default":     "json",
-					"required":    false,
-					"example":     "format=markdown",
+				keyFormat: map[string]any{
+					keyDescription: "Output format preference",
+					keyFormat:      formatStringDoc,
+					keyValues:      []string{formatJSON, formatXML, formatHTML, formatMarkdown},
+					keyDefault:     formatJSON,
+					keyRequired:    false,
+					keyExample:     "format=markdown",
 				},
 			},
 			"usage_examples": []map[string]any{
 				{
-					"description": "Get recent tech articles with media",
-					"uri":         "feeds://feed/{feedId}/items?since=2023-01-01T00:00:00Z&category=technology&has_media=true&limit=10",
+					keyDescription: "Get recent tech articles with media",
+					keyURI:         "feeds://feed/{feedId}/items?since=2023-01-01T00:00:00Z&category=technology&has_media=true&limit=10",
 				},
 				{
-					"description": "Search for specific content in a date range",
-					"uri":         "feeds://feed/{feedId}/items?search=golang&since=2023-01-01T00:00:00Z&until=2023-12-31T23:59:59Z",
+					keyDescription: "Search for specific content in a date range",
+					keyURI:         "feeds://feed/{feedId}/items?search=golang&since=2023-01-01T00:00:00Z&until=2023-12-31T23:59:59Z",
 				},
 				{
-					"description": "Get paginated results without duplicates",
-					"uri":         "feeds://feed/{feedId}/items?limit=20&offset=40&duplicates=false",
+					keyDescription: "Get paginated results without duplicates",
+					keyURI:         "feeds://feed/{feedId}/items?limit=20&offset=40&duplicates=false",
 				},
 			},
 			"combination_notes": []string{
@@ -550,7 +550,7 @@ func (rm *ResourceManager) readFeed(ctx context.Context, uri string) (*mcp.ReadR
 		content := map[string]any{
 			"feed_result": &filteredResult,
 			"filter_info": filterSummary,
-			"updated_at":  time.Now().UTC(),
+			keyUpdatedAt:  time.Now().UTC(),
 		}
 
 		contentJSON, err := marshalJSONContent(content, uri)
@@ -655,7 +655,7 @@ func (rm *ResourceManager) readFeedItems(ctx context.Context, uri string) (*mcp.
 		"items":       filteredItems,
 		"count":       filteredCount,
 		"filter_info": filterSummary,
-		"updated_at":  time.Now().UTC(),
+		keyUpdatedAt:  time.Now().UTC(),
 	}
 
 	contentJSON, err := marshalJSONContent(content, uri)
@@ -721,17 +721,17 @@ func (rm *ResourceManager) readFeedMeta(ctx context.Context, uri string) (*mcp.R
 	// Extract only metadata fields from FeedResult and its nested Feed
 	metadata := map[string]any{
 		"id":                   feedID,
-		"title":                feedResult.Title,
+		keyTitle:               feedResult.Title,
 		"public_url":           feedResult.PublicURL,
 		"has_error":            feedResult.FetchError != "",
 		"fetch_error":          feedResult.FetchError,
 		"circuit_breaker_open": feedResult.CircuitBreakerOpen,
-		"updated_at":           time.Now().UTC(),
+		keyUpdatedAt:           time.Now().UTC(),
 	}
 
 	// Add Feed-specific metadata if available
 	if feedResult.Feed != nil {
-		metadata["description"] = feedResult.Feed.Description
+		metadata[keyDescription] = feedResult.Feed.Description
 		metadata["link"] = feedResult.Feed.Link
 		metadata["feed_link"] = feedResult.Feed.FeedLink
 		metadata["language"] = feedResult.Feed.Language
@@ -1129,9 +1129,9 @@ func (rm *ResourceManager) DetectResourceChanges(ctx context.Context) ([]string,
 		// For each feed, assume all its resources might have changed
 		// In a real implementation, you'd check timestamps, content hashes, etc.
 		changedURIs = append(changedURIs,
-			expandURITemplate(FeedURI, map[string]string{"feedId": feedID}),
-			expandURITemplate(FeedItemsURI, map[string]string{"feedId": feedID}),
-			expandURITemplate(FeedMetaURI, map[string]string{"feedId": feedID}),
+			expandURITemplate(FeedURI, map[string]string{keyFeedID: feedID}),
+			expandURITemplate(FeedItemsURI, map[string]string{keyFeedID: feedID}),
+			expandURITemplate(FeedMetaURI, map[string]string{keyFeedID: feedID}),
 		)
 	}
 

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -240,7 +240,7 @@ func (s *Server) buildMCPServer() *mcp.Server {
 func (s *Server) createMCPServer() *mcp.Server {
 	return mcp.NewServer(
 		&mcp.Implementation{
-			Name:    "RSS, Atom, and JSON Feed Server",
+			Name:    serverName,
 			Version: version.GetVersion(),
 		},
 		&mcp.ServerOptions{
@@ -261,15 +261,15 @@ func (s *Server) registerCoreTools(srv *mcp.Server) {
 // addFetchLinkTool adds the fetch_link tool
 func (s *Server) addFetchLinkTool(srv *mcp.Server) {
 	fetchLinkTool := &mcp.Tool{
-		Name:        "fetch_link",
-		Description: "Fetch link URL",
+		Name:        toolFetchLink,
+		Description: fetchLinkDescription,
 		InputSchema: &jsonschema.Schema{
-			Type:     "object",
-			Required: []string{"URL"},
+			Type:     typeObject,
+			Required: []string{keyURL},
 			Properties: map[string]*jsonschema.Schema{
-				"URL": {
-					Type:        "string",
-					Description: "Link URL",
+				keyURL: {
+					Type:        typeString,
+					Description: linkURLDescription,
 				},
 			},
 		},
@@ -293,9 +293,9 @@ func (s *Server) addFetchLinkTool(srv *mcp.Server) {
 // addAllFeedsTool adds the all_syndication_feeds tool
 func (s *Server) addAllFeedsTool(srv *mcp.Server) {
 	allFeedsTool := &mcp.Tool{
-		Name:        "all_syndication_feeds",
+		Name:        toolAllSyndicationFeeds,
 		Description: "list available feedItem resources",
-		InputSchema: &jsonschema.Schema{Type: "object"},
+		InputSchema: &jsonschema.Schema{Type: typeObject},
 	}
 	mcp.AddTool(srv, allFeedsTool, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
 		feedResults, err := s.allFeedsGetter.GetAllFeeds(ctx)
@@ -319,42 +319,42 @@ func (s *Server) addAllFeedsTool(srv *mcp.Server) {
 // addGetFeedItemsTool adds the get_syndication_feed_items tool to the server
 func (s *Server) addGetFeedItemsTool(srv *mcp.Server) {
 	getSyndicationFeedTool := &mcp.Tool{
-		Name:        "get_syndication_feed_items",
+		Name:        toolGetSyndicationFeedItems,
 		Description: "Get feed items with metadata-only by default (title, link, date). Use two-pass workflow: 1) Browse with defaults to see available items, 2) Read specific items with includeContent=true. Prevents conversation length errors by excluding large content/description fields unless explicitly requested.",
 		InputSchema: &jsonschema.Schema{
-			Type:     "object",
-			Required: []string{"ID"},
+			Type:     typeObject,
+			Required: []string{keyID},
 			Properties: map[string]*jsonschema.Schema{
-				"ID": {
-					Type:        "string",
+				keyID: {
+					Type:        typeString,
 					Description: "Feed ID from all_syndication_feeds tool",
 				},
 				"limit": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Description: fmt.Sprintf("Maximum items to return (default: %d, max: %d). Use smaller values when includeContent=true to avoid conversation length errors.", DefaultItemLimit, MaxItemLimit),
 					Minimum:     &[]float64{0}[0],
 					Maximum:     &[]float64{float64(MaxItemLimit)}[0],
 				},
 				"offset": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Description: "Number of items to skip for pagination (default: 0). Use with limit to navigate pages of results.",
 					Minimum:     &[]float64{0}[0],
 				},
 				"includeContent": {
-					Type:        "boolean",
+					Type:        typeBoolean,
 					Description: "Whether to include content/description fields (default: false). Leave false for browsing (metadata only: title, link, date, author). Set true only when reading specific items to avoid large responses.",
 				},
 				"maxContentLength": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Description: fmt.Sprintf("Maximum characters for content/description fields (default: %d when includeContent=true, 0 for unlimited). Use to preview content without full articles.", DefaultContentLength),
 					Minimum:     &[]float64{0}[0],
 				},
 				"includeImages": {
-					Type:        "boolean",
+					Type:        typeBoolean,
 					Description: "Whether to include images from feed items (default: false). When false: no images. When true with embedImages=false: returns ResourceLinks (~100 bytes each, URLs only). When true with embedImages=true: returns ImageContent (base64-encoded, displays inline in Claude Desktop). All images include Meta: {\"itemIndex\": N} for association with feed item at position N.",
 				},
 				"embedImages": {
-					Type:        "boolean",
+					Type:        typeBoolean,
 					Description: "Fetch and embed images as base64 ImageContent for inline display (default: false). Requires includeImages=true. Images are cached, rate-limited, and subject to: 1MB size limit per image (Claude Desktop constraint), circuit breaker protection (3 failures = skip host), 5s timeout per fetch. Failed fetches are skipped gracefully.",
 				},
 			},
@@ -512,14 +512,14 @@ func (s *Server) buildFeedContent(ctx context.Context, feedResult *model.FeedAnd
 					if err != nil {
 						// Log error but continue with other images (graceful degradation)
 						// Fall back to ResourceLink on failure
-						link.Meta = mcp.Meta{"itemIndex": i}
+						link.Meta = mcp.Meta{keyItemIndex: i}
 						content = append(content, link)
 						continue
 					}
 					content = append(content, imageContent)
 				} else {
 					// Return as ResourceLink (lightweight URL reference)
-					link.Meta = mcp.Meta{"itemIndex": i}
+					link.Meta = mcp.Meta{keyItemIndex: i}
 					content = append(content, link)
 				}
 			}
@@ -590,32 +590,32 @@ func (s *Server) addAggregationTools(srv *mcp.Server) {
 		Name:        "merge_feeds",
 		Description: "Merge multiple feeds into a single aggregated feed with deduplication and sorting",
 		InputSchema: &jsonschema.Schema{
-			Type:     "object",
-			Required: []string{"feedIds"},
+			Type:     typeObject,
+			Required: []string{keyFeedIDs},
 			Properties: map[string]*jsonschema.Schema{
-				"feedIds": {
+				keyFeedIDs: {
 					Type:        "array",
 					Description: "Array of feed IDs to merge",
 					Items: &jsonschema.Schema{
-						Type: "string",
+						Type: typeString,
 					},
 				},
-				"title": {
-					Type:        "string",
+				keyTitle: {
+					Type:        typeString,
 					Description: "Title for the merged feed",
 				},
 				"maxItems": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Description: "Maximum number of items to include (0 for no limit)",
 					Minimum:     &[]float64{0}[0],
 				},
 				"sortBy": {
-					Type:        "string",
+					Type:        typeString,
 					Description: "Sort order: date (default), title, source",
-					Enum:        []any{"date", "title", "source"},
+					Enum:        []any{sortByDate, keyTitle, valueSource},
 				},
 				"deduplicate": {
-					Type:        "boolean",
+					Type:        typeBoolean,
 					Description: "Remove duplicate items based on title and link",
 				},
 			},
@@ -642,36 +642,36 @@ func (s *Server) addAggregationTools(srv *mcp.Server) {
 		Name:        "export_feed_data",
 		Description: "Export feed data in various formats (JSON, CSV, OPML, RSS, Atom)",
 		InputSchema: &jsonschema.Schema{
-			Type:     "object",
-			Required: []string{"format"},
+			Type:     typeObject,
+			Required: []string{keyFormat},
 			Properties: map[string]*jsonschema.Schema{
-				"feedIds": {
+				keyFeedIDs: {
 					Type:        "array",
 					Description: "Feed IDs to export (empty for all feeds)",
 					Items: &jsonschema.Schema{
-						Type: "string",
+						Type: typeString,
 					},
 				},
-				"format": {
-					Type:        "string",
+				keyFormat: {
+					Type:        typeString,
 					Description: "Export format",
-					Enum:        []any{"json", "csv", "opml", "rss", "atom"},
+					Enum:        []any{formatJSON, formatCSV, formatOPML, formatRSS, formatAtom},
 				},
 				"since": {
-					Type:        "string",
+					Type:        typeString,
 					Description: "Include items published after this date (ISO 8601)",
 				},
 				"until": {
-					Type:        "string",
+					Type:        typeString,
 					Description: "Include items published before this date (ISO 8601)",
 				},
 				"maxItems": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Description: "Maximum number of items per feed (0 for no limit)",
 					Minimum:     &[]float64{0}[0],
 				},
 				"includeAll": {
-					Type:        "boolean",
+					Type:        typeBoolean,
 					Description: "Include all feed metadata and statistics",
 				},
 			},
@@ -708,23 +708,23 @@ func (s *Server) addAddFeedTool(srv *mcp.Server) {
 		Name:        "add_feed",
 		Description: "Add a new RSS/Atom/JSON feed at runtime",
 		InputSchema: &jsonschema.Schema{
-			Type:     "object",
-			Required: []string{"url"},
+			Type:     typeObject,
+			Required: []string{keyURLLower},
 			Properties: map[string]*jsonschema.Schema{
-				"url": {
-					Type:        "string",
+				keyURLLower: {
+					Type:        typeString,
 					Description: "RSS/Atom/JSON feed URL",
 				},
-				"title": {
-					Type:        "string",
+				keyTitle: {
+					Type:        typeString,
 					Description: "Optional human-readable title",
 				},
 				"category": {
-					Type:        "string",
+					Type:        typeString,
 					Description: "Optional category for organization",
 				},
-				"description": {
-					Type:        "string",
+				keyDescription: {
+					Type:        typeString,
 					Description: "Optional description",
 				},
 			},
@@ -755,20 +755,20 @@ func (s *Server) addRemoveFeedTool(srv *mcp.Server) {
 		Name:        "remove_feed",
 		Description: "Remove a feed by ID or URL",
 		InputSchema: &jsonschema.Schema{
-			Type: "object",
+			Type: typeObject,
 			Properties: map[string]*jsonschema.Schema{
-				"feedId": {
-					Type:        "string",
+				keyFeedID: {
+					Type:        typeString,
 					Description: "Feed ID to remove",
 				},
-				"url": {
-					Type:        "string",
+				keyURLLower: {
+					Type:        typeString,
 					Description: "Feed URL to remove",
 				},
 			},
 			OneOf: []*jsonschema.Schema{
-				{Required: []string{"feedId"}},
-				{Required: []string{"url"}},
+				{Required: []string{keyFeedID}},
+				{Required: []string{keyURLLower}},
 			},
 		},
 	}
@@ -806,7 +806,7 @@ func (s *Server) addListManagedFeedsTool(srv *mcp.Server) {
 	listManagedFeedsTool := &mcp.Tool{
 		Name:        "list_managed_feeds",
 		Description: "List all managed feeds with metadata and status",
-		InputSchema: &jsonschema.Schema{Type: "object"}, // No parameters needed
+		InputSchema: &jsonschema.Schema{Type: typeObject}, // No parameters needed
 	}
 	mcp.AddTool(srv, listManagedFeedsTool, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
 		feeds, err := s.dynamicFeedManager.ListManagedFeeds(ctx)
@@ -831,11 +831,11 @@ func (s *Server) addRefreshFeedTool(srv *mcp.Server) {
 		Name:        "refresh_feed",
 		Description: "Force refresh a specific feed to get latest content",
 		InputSchema: &jsonschema.Schema{
-			Type:     "object",
-			Required: []string{"feedId"},
+			Type:     typeObject,
+			Required: []string{keyFeedID},
 			Properties: map[string]*jsonschema.Schema{
-				"feedId": {
-					Type:        "string",
+				keyFeedID: {
+					Type:        typeString,
 					Description: "Feed ID to refresh",
 				},
 			},
@@ -1007,7 +1007,7 @@ func (s *Server) addPrompts(srv *mcp.Server) {
 			Description: "Analyze trends and patterns across multiple feeds over time",
 			Arguments: []*mcp.PromptArgument{
 				{
-					Name:        "timeframe",
+					Name:        keyTimeframe,
 					Description: "Time period to analyze (e.g., '24h', '7d', '30d')",
 					Required:    false,
 				},
@@ -1052,7 +1052,7 @@ func (s *Server) addPrompts(srv *mcp.Server) {
 					Required:    true,
 				},
 				{
-					Name:        "timeframe",
+					Name:        keyTimeframe,
 					Description: "Time period to monitor (e.g., '24h', '7d') - defaults to '24h'",
 					Required:    false,
 				},
@@ -1097,7 +1097,7 @@ func (s *Server) addPrompts(srv *mcp.Server) {
 					Required:    false,
 				},
 				{
-					Name:        "timeframe",
+					Name:        keyTimeframe,
 					Description: "Time period for the report (e.g., '7d', '30d', '90d')",
 					Required:    false,
 				},
@@ -1114,7 +1114,7 @@ func (s *Server) mergeFeeds(ctx context.Context, args MergeFeedsParams) (*Merged
 
 	// Default values
 	if args.SortBy == "" {
-		args.SortBy = "date"
+		args.SortBy = sortByDate
 	}
 
 	// Fetch all specified feeds
@@ -1138,9 +1138,9 @@ func (s *Server) mergeFeeds(ctx context.Context, args MergeFeedsParams) (*Merged
 
 	// Sort items based on sortBy parameter
 	switch args.SortBy {
-	case "title":
+	case keyTitle:
 		sortItemsByTitle(allItems)
-	case "source":
+	case valueSource:
 		sortItemsBySource(allItems)
 	default: // "date"
 		sortItemsByDate(allItems)
@@ -1248,15 +1248,15 @@ func (s *Server) applyExportFilters(feedResults []*FeedAndItemsResult, args *Exp
 // exportInFormat exports the feed results in the requested format
 func (s *Server) exportInFormat(feedResults []*FeedAndItemsResult, args *ExportFeedDataParams) (string, error) {
 	switch args.Format {
-	case "json":
+	case formatJSON:
 		return exportAsJSON(feedResults, args.IncludeAll)
-	case "csv":
+	case formatCSV:
 		return exportAsCSV(feedResults)
-	case "opml":
+	case formatOPML:
 		return exportAsOPML(feedResults)
-	case "rss":
+	case formatRSS:
 		return exportAsRSS(feedResults)
-	case "atom":
+	case formatAtom:
 		return exportAsAtom(feedResults)
 	default:
 		return "", model.NewFeedError(model.ErrorTypeValidation, fmt.Sprintf("unsupported export format: %s", args.Format)).
@@ -1455,7 +1455,7 @@ func (s *Server) fetchAndEmbedImage(ctx context.Context, imageURL, mimeType stri
 		return &mcp.ImageContent{
 			Data:     cachedData,
 			MIMEType: mimeType,
-			Meta:     mcp.Meta{"itemIndex": itemIndex},
+			Meta:     mcp.Meta{keyItemIndex: itemIndex},
 		}, nil
 	}
 
@@ -1517,7 +1517,7 @@ func (s *Server) fetchAndEmbedImage(ctx context.Context, imageURL, mimeType stri
 	return &mcp.ImageContent{
 		Data:     encodedData,
 		MIMEType: mimeType,
-		Meta:     mcp.Meta{"itemIndex": itemIndex},
+		Meta:     mcp.Meta{keyItemIndex: itemIndex},
 	}, nil
 }
 
@@ -1575,8 +1575,8 @@ func sortItemsBySource(items []*gofeed.Item) {
 
 // getItemSource extracts source information from a feed item
 func getItemSource(item *gofeed.Item) string {
-	if item.Custom != nil && item.Custom["source"] != "" {
-		return item.Custom["source"]
+	if item.Custom != nil && item.Custom[valueSource] != "" {
+		return item.Custom[valueSource]
 	}
 	return ""
 }

--- a/model/error_helpers.go
+++ b/model/error_helpers.go
@@ -13,6 +13,12 @@ import (
 	"time"
 )
 
+// Repeated error/format message strings.
+const (
+	msgConnectionFailed = "Connection failed"
+	feedFormatRSS       = "RSS"
+)
+
 // CreateNetworkError creates a FeedError for network-related issues
 func CreateNetworkError(err error, feedURL string) *FeedError {
 	errorType := ErrorTypeNetwork
@@ -29,7 +35,7 @@ func CreateNetworkError(err error, feedURL string) *FeedError {
 			message = "DNS resolution failed"
 		} else if isConnectionError(err) {
 			errorType = ErrorTypeConnectionFailed
-			message = "Connection failed"
+			message = msgConnectionFailed
 		}
 	}
 
@@ -315,7 +321,7 @@ func determineFeedFormat(content string) string {
 	}
 	if strings.HasPrefix(contentLower, "<") {
 		if strings.Contains(contentLower, "<rss") {
-			return "RSS"
+			return feedFormatRSS
 		}
 		if strings.Contains(contentLower, "<feed") {
 			return "Atom"

--- a/model/transport.go
+++ b/model/transport.go
@@ -7,6 +7,15 @@ import (
 // ErrInvalidTransport is returned when an invalid transport type is specified.
 var ErrInvalidTransport = errors.New("invalid transport")
 
+// Transport name strings used for parsing and string representation.
+const (
+	transportNameStdio = "stdio"
+	// transportNameHTTPWithSSE is a transport identifier, not a credential.
+	transportNameHTTPWithSSE    = "http-with-sse" //nolint:gosec // G101 false positive: transport name, not a secret
+	transportNameStreamableHTTP = "streamable-http"
+	transportNameUndefined      = "undefined"
+)
+
 // Transport represents the communication transport method for the MCP server
 type Transport uint8
 
@@ -21,12 +30,12 @@ const (
 // ParseTransport converts a string to a Transport type
 func ParseTransport(transport string) (Transport, error) {
 	switch transport {
-	case "stdio":
+	case transportNameStdio:
 		return StdioTransport, nil
-	case "http-with-sse":
+	case transportNameHTTPWithSSE:
 		// Deprecated: maps to StreamableHTTPTransport for backwards compatibility
 		return StreamableHTTPTransport, nil
-	case "streamable-http":
+	case transportNameStreamableHTTP:
 		return StreamableHTTPTransport, nil
 	default:
 		return UndefinedTransport, ErrInvalidTransport
@@ -37,12 +46,12 @@ func ParseTransport(transport string) (Transport, error) {
 func (t Transport) String() string {
 	switch t {
 	case StdioTransport:
-		return "stdio"
+		return transportNameStdio
 	case HTTPWithSSETransport:
-		return "http-with-sse" // Deprecated
+		return transportNameHTTPWithSSE // Deprecated
 	case StreamableHTTPTransport:
-		return "streamable-http"
+		return transportNameStreamableHTTP
 	default:
-		return "undefined"
+		return transportNameUndefined
 	}
 }

--- a/model/url_validation.go
+++ b/model/url_validation.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+// Loopback host/address values used for localhost detection.
+const (
+	loopbackHostname = "localhost"
+	loopbackIPv4     = "127.0.0.1"
+	loopbackIPv6     = "::1"
+)
+
 // URL validation errors
 var (
 	ErrInvalidURL        = errors.New("invalid URL format")
@@ -102,9 +109,9 @@ func isLocalhost(hostname string) bool {
 	hostname = strings.ToLower(hostname)
 
 	localhostPatterns := []string{
-		"localhost",
-		"127.0.0.1",
-		"::1",
+		loopbackHostname,
+		loopbackIPv4,
+		loopbackIPv6,
 		"[::1]", // IPv6 with brackets
 	}
 

--- a/performance/resource_benchmarks.go
+++ b/performance/resource_benchmarks.go
@@ -322,7 +322,9 @@ func generateFeedID(url string) string {
 	// Simple hash function for testing (matches the one in resources.go)
 	hash := uint32(0)
 	for _, c := range url {
-		hash = hash*31 + uint32(c)
+		// G115 false positive: a rune is a non-negative Unicode code point, and the
+		// wraparound in this non-cryptographic hash is intentional.
+		hash = hash*31 + uint32(c) //nolint:gosec
 	}
 	return fmt.Sprintf("%x", hash)
 }

--- a/store/dynamic_feeds.go
+++ b/store/dynamic_feeds.go
@@ -397,7 +397,7 @@ func (ds *DynamicStore) RefreshFeed(ctx context.Context, feedID string) (*mcpser
 	}
 
 	if err != nil {
-		refreshInfo.Status = "error"
+		refreshInfo.Status = statusError
 		refreshInfo.Error = err.Error()
 
 		// Update metadata

--- a/store/store.go
+++ b/store/store.go
@@ -24,6 +24,9 @@ import (
 	"github.com/richardwooding/feed-mcp/model"
 )
 
+// keyAttempt is the structured-log field key for the current retry attempt.
+const keyAttempt = "attempt"
+
 // HTTPPoolConfig holds HTTP connection pool configuration
 type HTTPPoolConfig struct {
 	MaxIdleConns        int
@@ -258,7 +261,7 @@ func retryableFeedFetch(ctx context.Context, url string, parser *gofeed.Parser, 
 			}
 			msg := "Successfully fetched feed"
 			if attempt > 1 {
-				extra["attempt"] = attempt
+				extra[keyAttempt] = attempt
 				extra["max_attempts"] = maxAttempts
 				msg = fmt.Sprintf("Successfully fetched feed after %d attempts", attempt)
 			}
@@ -278,9 +281,9 @@ func retryableFeedFetch(ctx context.Context, url string, parser *gofeed.Parser, 
 			fmt.Sprintf("Feed fetch attempt %d failed", attempt),
 			"feed_fetcher", "retryable_fetch", url,
 			map[string]any{
-				"attempt":      attempt,
+				keyAttempt:     attempt,
 				"max_attempts": maxAttempts,
-				"error":        err.Error(),
+				statusError:    err.Error(),
 				"retryable":    isRetryableError(err),
 			},
 		)
@@ -292,8 +295,8 @@ func retryableFeedFetch(ctx context.Context, url string, parser *gofeed.Parser, 
 					"Error is not retryable, stopping retry attempts",
 					"feed_fetcher", "retryable_fetch", url,
 					map[string]any{
-						"attempt": attempt,
-						"error":   err.Error(),
+						keyAttempt:  attempt,
+						statusError: err.Error(),
 					},
 				)
 			}
@@ -307,7 +310,7 @@ func retryableFeedFetch(ctx context.Context, url string, parser *gofeed.Parser, 
 			fmt.Sprintf("Retrying in %v", delay),
 			"feed_fetcher", "retryable_fetch", url,
 			map[string]any{
-				"attempt":      attempt,
+				keyAttempt:     attempt,
 				"next_attempt": attempt + 1,
 				"delay_ms":     delay.Milliseconds(),
 			},


### PR DESCRIPTION
Part 2 of the tooling modernization (follows #125). Upgrades golangci-lint to the latest release and resolves the additional findings it surfaces that v2.9.0 silently ignored.

## Changes
- **golangci-lint v2.9.0 → v2.12.2** in `Makefile` (`GOLANGCI_LINT_VERSION`) and `.github/workflows/go.yml`.
- **`go.mod`: `toolchain go1.26.4`** pinned for reproducible builds. (Go is already on the latest 1.26 line; 1.27 is unreleased — no minor bump needed.)
- **`.golangci.yml`: exclude `goconst` from `_test.go`** — tests legitimately repeat literal fixtures, matching the existing test-file exclusions (gocyclo/errcheck/dupl/gosec/gocritic). Removes 163 test-only findings.
- **Extract ~59 repeated production string literals into named constants** (new `mcpserver/constants.go` for the shared mcpserver set; `model`/`store` reuse the existing `statusError`). Covers JSON-schema keys & type values, tool names, transport identifiers, loopback addresses, sentiment/sort/format enums, and structured-log field keys. **Values are byte-for-byte identical — no behavior change.**
- **gosec**: justified `//nolint:gosec` for G115 (`rune→uint32` in a non-crypto hash) and G101 (a transport-name constant mis-flagged as a credential).

## Why the bump surfaces so much
v2.12.x's `goconst` counts occurrences (including test files) more aggressively than v2.9.0, and CI lint is a **blocking** step — so these had to be resolved for the upgrade to land.

## Verification
- `gofmt`, `go build ./...`, `go vet ./...`, full `go test ./...` — all pass.
- `golangci-lint run` with the new **v2.12.2** pin — **0 issues** (verified with the exact CI version installed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)