### PR TITLE
refactor(store): use hostrate for per-host rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/matoous/go-nanoid/v2 v2.1.0
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/richardwooding/hostrate v0.1.0
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/prometheus/common v0.67.4 h1:yR3NqWO1/UyO1w2PhUvXlGQs/PtFmoveVO0KZ4+L
 github.com/prometheus/common v0.67.4/go.mod h1:gP0fq6YjjNCLssJCQp0yk4M8W6ikLURwkdd/YKtTbyI=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/richardwooding/hostrate v0.1.0 h1:oRlKmj+2UVKxV3QhQBhSsGi9cq8uXIqtCGpw6kMWnBI=
+github.com/richardwooding/hostrate v0.1.0/go.mod h1:pwdl6/mK9Cm0+mkJoZYTK1E37Q9OnTfeJD1fY/VBnzc=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/eko/gocache/lib/v4/store"
 	ristretto_store "github.com/eko/gocache/store/ristretto/v4"
 	"github.com/mmcdole/gofeed"
+	"github.com/richardwooding/hostrate"
 	"github.com/sony/gobreaker"
 	"golang.org/x/time/rate"
 
@@ -79,40 +80,10 @@ type Store struct {
 	metricsMutex     sync.RWMutex
 }
 
-// RateLimitedTransport wraps an http.RoundTripper with per-host rate limiting.
-// A separate token bucket is maintained for each remote host so that fetches
-// against many distinct hosts are not artificially serialized, while requests
-// to any single host remain bounded by the configured rate and burst.
-type RateLimitedTransport struct {
-	transport         http.RoundTripper
-	requestsPerSecond rate.Limit
-	burstCapacity     int
-	limiters          sync.Map // host (string) -> *rate.Limiter
-}
-
-// limiterForHost returns the limiter associated with host, creating one on first use.
-func (r *RateLimitedTransport) limiterForHost(host string) *rate.Limiter {
-	if v, ok := r.limiters.Load(host); ok {
-		return v.(*rate.Limiter)
-	}
-	v, _ := r.limiters.LoadOrStore(host, rate.NewLimiter(r.requestsPerSecond, r.burstCapacity))
-	return v.(*rate.Limiter)
-}
-
-// RoundTrip implements the http.RoundTripper interface with per-host rate limiting.
-func (r *RateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	host := strings.ToLower(req.URL.Hostname())
-	if err := r.limiterForHost(host).Wait(req.Context()); err != nil {
-		return nil, err
-	}
-	return r.transport.RoundTrip(req)
-}
-
-// NewRateLimitedHTTPClient creates an HTTP client with per-host rate limiting and connection pooling.
-// The requestsPerSecond and burstCapacity arguments configure each host's token bucket independently.
-func NewRateLimitedHTTPClient(requestsPerSecond float64, burstCapacity int, poolConfig HTTPPoolConfig) *http.Client {
-	// Create a custom transport with connection pooling settings
-	baseTransport := &http.Transport{
+// newPooledTransport builds an *http.Transport with the given connection pool
+// settings, otherwise mirroring http.DefaultTransport's defaults.
+func newPooledTransport(poolConfig HTTPPoolConfig) *http.Transport {
+	return &http.Transport{
 		MaxIdleConns:        poolConfig.MaxIdleConns,
 		MaxConnsPerHost:     poolConfig.MaxConnsPerHost,
 		MaxIdleConnsPerHost: poolConfig.MaxIdleConnsPerHost,
@@ -127,12 +98,13 @@ func NewRateLimitedHTTPClient(requestsPerSecond float64, burstCapacity int, pool
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+}
 
-	transport := &RateLimitedTransport{
-		transport:         baseTransport,
-		requestsPerSecond: rate.Limit(requestsPerSecond),
-		burstCapacity:     burstCapacity,
-	}
+// NewRateLimitedHTTPClient creates an HTTP client with per-host rate limiting and connection pooling.
+// The requestsPerSecond and burstCapacity arguments configure each host's token bucket independently.
+// Per-host rate limiting is provided by github.com/richardwooding/hostrate.
+func NewRateLimitedHTTPClient(requestsPerSecond float64, burstCapacity int, poolConfig HTTPPoolConfig) *http.Client {
+	transport := hostrate.New(newPooledTransport(poolConfig), rate.Limit(requestsPerSecond), burstCapacity)
 
 	return &http.Client{
 		Transport: transport,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/richardwooding/hostrate"
 )
 
 func mockFeedServer(t *testing.T, title string) *httptest.Server {
@@ -178,9 +180,9 @@ func TestNewRateLimitedHTTPClient(t *testing.T) {
 		t.Errorf("expected timeout to be 30s, got %v", client.Timeout)
 	}
 
-	// Verify it's our custom transport
-	if _, ok := client.Transport.(*RateLimitedTransport); !ok {
-		t.Error("expected RateLimitedTransport")
+	// Verify it's the per-host rate-limiting transport
+	if _, ok := client.Transport.(*hostrate.Transport); !ok {
+		t.Errorf("expected *hostrate.Transport, got %T", client.Transport)
 	}
 }
 
@@ -799,23 +801,9 @@ func TestNewRateLimitedHTTPClient_ConnectionPoolSettings(t *testing.T) {
 		IdleConnTimeout:     120 * time.Second,
 	}
 
-	client := NewRateLimitedHTTPClient(2.0, 3, poolConfig)
-
-	if client == nil {
-		t.Fatal("expected client to be non-nil")
-	}
-
-	// Verify it's our custom transport
-	rateLimitedTransport, ok := client.Transport.(*RateLimitedTransport)
-	if !ok {
-		t.Fatal("expected RateLimitedTransport")
-	}
-
-	// Verify the underlying transport is our custom HTTP transport
-	httpTransport, ok := rateLimitedTransport.transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected underlying transport to be *http.Transport")
-	}
+	// The pooled base transport is wrapped by hostrate (whose base field is
+	// unexported), so verify the pool settings on the builder directly.
+	httpTransport := newPooledTransport(poolConfig)
 
 	// Verify connection pool settings
 	if httpTransport.MaxIdleConns != 75 {
@@ -1573,87 +1561,6 @@ func TestNewStore_LazyStartup(t *testing.T) {
 	}
 }
 
-// fakeRoundTripper returns an empty 200 response without making a network call,
-// so RateLimitedTransport tests measure only the limiter's wait time.
-type fakeRoundTripper struct{}
-
-func (f *fakeRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-// newTestRequest builds a GET request for the given hostname (no real network use).
-func newTestRequest(t *testing.T, host string) *http.Request {
-	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, "http://"+host+"/", nil)
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
-	}
-	return req
-}
-
-// TestRateLimitedTransport_PerHost verifies that requests to different hosts
-// proceed in parallel rather than serializing through a global limiter.
-func TestRateLimitedTransport_PerHost(t *testing.T) {
-	rt := &RateLimitedTransport{
-		transport:         &fakeRoundTripper{},
-		requestsPerSecond: 1.0, // very restrictive: a global limiter would force ~1s wait
-		burstCapacity:     1,
-	}
-
-	start := time.Now()
-	done := make(chan error, 2)
-	for _, host := range []string{"host-a.example", "host-b.example"} {
-		go func(h string) {
-			resp, err := rt.RoundTrip(newTestRequest(t, h))
-			if err == nil {
-				_ = resp.Body.Close()
-			}
-			done <- err
-		}(host)
-	}
-	for range 2 {
-		if err := <-done; err != nil {
-			t.Fatalf("RoundTrip failed: %v", err)
-		}
-	}
-	elapsed := time.Since(start)
-
-	// With per-host limiters each host has its own burst token, so both calls
-	// proceed immediately. A global limiter at burst 1 would force the second
-	// caller to wait ~1 second.
-	if elapsed > 200*time.Millisecond {
-		t.Fatalf("parallel cross-host requests took %v; expected <200ms with per-host limiting", elapsed)
-	}
-}
-
-// TestRateLimitedTransport_SameHostStillLimited verifies the per-host limiter
-// still throttles repeated requests to the same host.
-func TestRateLimitedTransport_SameHostStillLimited(t *testing.T) {
-	rt := &RateLimitedTransport{
-		transport:         &fakeRoundTripper{},
-		requestsPerSecond: 5.0, // 200ms per token after burst is spent
-		burstCapacity:     1,
-	}
-
-	start := time.Now()
-	for i := range 2 {
-		resp, err := rt.RoundTrip(newTestRequest(t, "host-c.example"))
-		if err != nil {
-			t.Fatalf("RoundTrip %d failed: %v", i, err)
-		}
-		_ = resp.Body.Close()
-	}
-	elapsed := time.Since(start)
-
-	// First request consumes the burst token; second waits ~200ms for a refill.
-	if elapsed < 150*time.Millisecond {
-		t.Fatalf("two same-host requests took only %v; expected ~200ms throttle", elapsed)
-	}
-	if elapsed > 1*time.Second {
-		t.Fatalf("two same-host requests took %v; throttling too aggressive", elapsed)
-	}
-}
+// Per-host rate-limiting behavior (cross-host parallelism and same-host
+// throttling) is now provided and tested by github.com/richardwooding/hostrate.
+// See TestPerHostIsolation in that module.


### PR DESCRIPTION
Replaces the in-repo `RateLimitedTransport` with the newly extracted [**hostrate**](https://github.com/richardwooding/hostrate) library (v0.1.0) — a standalone, independently-tested per-host rate-limiting `http.RoundTripper`.

## Changes
- `NewRateLimitedHTTPClient` now builds the tuned pooled `*http.Transport` (extracted into `newPooledTransport`) and wraps it with `hostrate.New(...)`.
- Removed the in-repo `RateLimitedTransport` type, `limiterForHost`, and `RoundTrip`.
- **Behavior is identical**: per-host token buckets at the configured rate/burst (defaults 2 req/s, burst 5), context-aware waiting. `hostrate`'s default `KeyByHost` matches the previous `strings.ToLower(req.URL.Hostname())` keying.

## Tests
- Retargeted transport type assertions to `*hostrate.Transport`.
- Connection-pool-settings test now verifies `newPooledTransport` directly (hostrate's base transport is unexported).
- Dropped the per-host limiter unit tests — that behavior now lives in (and is tested by) hostrate (`TestPerHostIsolation`). Net −118 lines.

## Why
hostrate fills a real ecosystem gap (no canonical per-host outbound limiter in Go) and is now reusable by others. This PR makes feed-mcp the first consumer.

## Verification
- `go build ./...`, `go vet ./...`, full `go test ./...` (incl. the rate-limit timing test) — all pass.
- golangci-lint **v2.12.2** — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)