### PR TITLE
refactor(model): use ssrfguard for URL/SSRF validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/richardwooding/hostrate v0.1.0
+	github.com/richardwooding/ssrfguard v0.1.0
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/richardwooding/hostrate v0.1.0 h1:oRlKmj+2UVKxV3QhQBhSsGi9cq8uXIqtCGpw6kMWnBI=
 github.com/richardwooding/hostrate v0.1.0/go.mod h1:pwdl6/mK9Cm0+mkJoZYTK1E37Q9OnTfeJD1fY/VBnzc=
+github.com/richardwooding/ssrfguard v0.1.0 h1:fv0X+eCMX81eHGgaYobCn1awLIF9dyRmrNO92PEGOdg=
+github.com/richardwooding/ssrfguard v0.1.0/go.mod h1:l26en+xGOtuFaRcpYqXkaCC2QdWggOyCw+DM5RzQpJQ=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/model/url_validation.go
+++ b/model/url_validation.go
@@ -3,20 +3,14 @@ package model
 import (
 	"errors"
 	"fmt"
-	"net"
-	"net/url"
-	"slices"
 	"strings"
+
+	"github.com/richardwooding/ssrfguard"
 )
 
-// Loopback host/address values used for localhost detection.
-const (
-	loopbackHostname = "localhost"
-	loopbackIPv4     = "127.0.0.1"
-	loopbackIPv6     = "::1"
-)
-
-// URL validation errors
+// URL validation errors. These remain the package's public sentinels (matched
+// with errors.Is by enhanced error reporting) and are mapped from the
+// equivalent github.com/richardwooding/ssrfguard errors.
 var (
 	ErrInvalidURL        = errors.New("invalid URL format")
 	ErrUnsupportedScheme = errors.New("unsupported URL scheme - only HTTP and HTTPS are allowed")
@@ -26,144 +20,37 @@ var (
 )
 
 // ValidateFeedURL validates a feed URL for security and format correctness.
-// Performs comprehensive security checks including scheme validation, host verification,
-// and optional private IP/localhost blocking to prevent SSRF attacks.
-// Returns an error if the URL fails any security or format validation checks.
+// It performs SSRF-focused checks — scheme validation, host verification, and
+// (unless allowPrivateIPs is set) blocking of private, loopback, link-local, and
+// metadata addresses — via github.com/richardwooding/ssrfguard, returning this
+// package's sentinel errors so callers can match them with errors.Is.
 func ValidateFeedURL(rawURL string, allowPrivateIPs bool) error {
-	if rawURL == "" {
+	guard := ssrfguard.New(ssrfguard.WithAllowPrivate(allowPrivateIPs))
+	return mapSSRFError(guard.ValidateURL(rawURL))
+}
+
+// mapSSRFError translates ssrfguard sentinel errors into this package's
+// equivalents, preserving the existing public error API.
+func mapSSRFError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ssrfguard.ErrEmptyURL):
 		return ErrEmptyURL
-	}
-
-	// Parse the URL
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
-	}
-
-	// Validate scheme
-	if err := validateScheme(u.Scheme); err != nil {
+	case errors.Is(err, ssrfguard.ErrUnsupportedScheme):
+		return ErrUnsupportedScheme
+	case errors.Is(err, ssrfguard.ErrMissingHost):
+		return ErrMissingHost
+	case errors.Is(err, ssrfguard.ErrBlockedAddress):
+		return ErrPrivateIPBlocked
+	case errors.Is(err, ssrfguard.ErrInvalidURL):
+		return ErrInvalidURL
+	default:
 		return err
 	}
-
-	// Validate host
-	if u.Host == "" {
-		return ErrMissingHost
-	}
-
-	// Check for private IPs if not allowed
-	if !allowPrivateIPs {
-		if err := validateHost(u.Host); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
-// validateScheme ensures only HTTP and HTTPS schemes are allowed.
-// Blocks potentially dangerous schemes like file://, ftp://, and data:// to prevent
-// various attack vectors including local file inclusion and data exfiltration.
-func validateScheme(scheme string) error {
-	scheme = strings.ToLower(scheme)
-	if scheme != "http" && scheme != "https" {
-		return ErrUnsupportedScheme
-	}
-	return nil
-}
-
-// validateHost checks if the host resolves to private IP ranges or localhost.
-// Performs DNS resolution and validates resolved IPs against private ranges (RFC 1918)
-// and localhost patterns to prevent SSRF attacks against internal services.
-// Allows temporarily unresolvable hosts to fail at HTTP request time.
-func validateHost(host string) error {
-	// Remove port if present
-	hostname, _, err := net.SplitHostPort(host)
-	if err != nil {
-		// If SplitHostPort fails, assume no port and use the whole host
-		hostname = host
-	}
-
-	// Check for localhost patterns
-	if isLocalhost(hostname) {
-		return ErrPrivateIPBlocked
-	}
-
-	// Try to resolve the hostname to IP addresses
-	ips, err := net.LookupIP(hostname)
-	if err != nil {
-		// If we can't resolve, let the HTTP client handle it later
-		// This avoids blocking valid URLs that might be temporarily unresolvable
-		return nil
-	}
-
-	// Check if any resolved IP is private
-	if slices.ContainsFunc(ips, isPrivateIP) {
-		return ErrPrivateIPBlocked
-	}
-
-	return nil
-}
-
-// isLocalhost checks for common localhost patterns
-func isLocalhost(hostname string) bool {
-	hostname = strings.ToLower(hostname)
-
-	localhostPatterns := []string{
-		loopbackHostname,
-		loopbackIPv4,
-		loopbackIPv6,
-		"[::1]", // IPv6 with brackets
-	}
-
-	if slices.Contains(localhostPatterns, hostname) {
-		return true
-	}
-
-	return strings.HasPrefix(hostname, "127.")
-}
-
-// isPrivateIP checks if an IP address is in a private range
-//
-//nolint:gocyclo // Function complexity is necessary for comprehensive private IP range validation (security requirement)
-func isPrivateIP(ip net.IP) bool {
-	// Check for IPv4 private ranges
-	if ip4 := ip.To4(); ip4 != nil {
-		// 10.0.0.0/8
-		if ip4[0] == 10 {
-			return true
-		}
-		// 172.16.0.0/12
-		if ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31 {
-			return true
-		}
-		// 192.168.0.0/16
-		if ip4[0] == 192 && ip4[1] == 168 {
-			return true
-		}
-		// 169.254.0.0/16 (link-local)
-		if ip4[0] == 169 && ip4[1] == 254 {
-			return true
-		}
-		// 127.0.0.0/8 (loopback)
-		if ip4[0] == 127 {
-			return true
-		}
-	}
-
-	// Check for IPv6 private ranges
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return true
-	}
-
-	// Check for IPv6 unique local addresses (fc00::/7)
-	if len(ip) == 16 && (ip[0]&0xfe) == 0xfc {
-		return true
-	}
-
-	return false
-}
-
-// SanitizeFeedURLs validates a slice of feed URLs
+// SanitizeFeedURLs validates a slice of feed URLs.
 func SanitizeFeedURLs(urls []string, allowPrivateIPs bool) error {
 	if len(urls) == 0 {
 		return errors.New("no feed URLs provided")

--- a/model/url_validation_test.go
+++ b/model/url_validation_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"net"
 	"strings"
 	"testing"
 )
@@ -143,117 +142,10 @@ func TestSanitizeFeedURLs(t *testing.T) {
 	}
 }
 
-func TestValidateScheme(t *testing.T) {
-	validSchemes := []string{"http", "https", "HTTP", "HTTPS", "Http", "Https"}
-	for _, scheme := range validSchemes {
-		t.Run("valid scheme: "+scheme, func(t *testing.T) {
-			if err := validateScheme(scheme); err != nil {
-				t.Errorf("scheme %q should be valid, got error: %v", scheme, err)
-			}
-		})
-	}
-
-	invalidSchemes := []string{"file", "ftp", "javascript", "data", "ldap", "gopher", "telnet", "ssh", ""}
-	for _, scheme := range invalidSchemes {
-		t.Run("invalid scheme: "+scheme, func(t *testing.T) {
-			if err := validateScheme(scheme); err == nil {
-				t.Errorf("scheme %q should be invalid", scheme)
-			}
-		})
-	}
-}
-
-func TestIsLocalhost(t *testing.T) {
-	localhosts := []string{"localhost", "LOCALHOST", "127.0.0.1", "127.1.1.1", "127.255.255.255", "::1"}
-	for _, host := range localhosts {
-		t.Run("localhost: "+host, func(t *testing.T) {
-			if !isLocalhost(host) {
-				t.Errorf("host %q should be detected as localhost", host)
-			}
-		})
-	}
-
-	nonLocalhosts := []string{"example.com", "192.168.1.1", "10.0.0.1", "google.com", "1.1.1.1"}
-	for _, host := range nonLocalhosts {
-		t.Run("not localhost: "+host, func(t *testing.T) {
-			if isLocalhost(host) {
-				t.Errorf("host %q should not be detected as localhost", host)
-			}
-		})
-	}
-}
-
-func TestIsPrivateIP(t *testing.T) {
-	tests := []struct {
-		name      string
-		ip        string
-		isPrivate bool
-	}{
-		// IPv4 private ranges
-		{"10.0.0.1", "10.0.0.1", true},
-		{"10.255.255.255", "10.255.255.255", true},
-		{"172.16.0.1", "172.16.0.1", true},
-		{"172.31.255.255", "172.31.255.255", true},
-		{"192.168.1.1", "192.168.1.1", true},
-		{"192.168.255.255", "192.168.255.255", true},
-		{"127.0.0.1", "127.0.0.1", true},
-		{"127.255.255.254", "127.255.255.254", true},
-		{"169.254.1.1", "169.254.1.1", true},
-
-		// IPv4 public ranges
-		{"8.8.8.8", "8.8.8.8", false},
-		{"1.1.1.1", "1.1.1.1", false},
-		{"173.0.0.1", "173.0.0.1", false},           // Just outside 172.16-31 range
-		{"172.15.255.255", "172.15.255.255", false}, // Just before 172.16-31 range
-		{"172.32.0.1", "172.32.0.1", false},         // Just after 172.16-31 range
-
-		// IPv6 addresses
-		{"::1", "::1", true},                  // IPv6 loopback
-		{"fe80::1", "fe80::1", true},          // IPv6 link-local
-		{"fc00::1", "fc00::1", true},          // IPv6 unique local
-		{"2001:db8::1", "2001:db8::1", false}, // IPv6 public
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ip := parseIP(tt.ip)
-			if ip == nil {
-				t.Fatalf("failed to parse IP %q", tt.ip)
-			}
-
-			result := isPrivateIP(ip)
-			if result != tt.isPrivate {
-				t.Errorf("isPrivateIP(%q) = %v, want %v", tt.ip, result, tt.isPrivate)
-			}
-		})
-	}
-}
-
-// Helper function for tests
-func parseIP(s string) net.IP {
-	if ip := net.ParseIP(s); ip != nil {
-		return ip
-	}
-	return nil
-}
-
-// Integration test with actual network resolution
-func TestValidateHostIntegration(t *testing.T) {
-	// Test with a known public domain
-	if err := validateHost("example.com"); err != nil {
-		t.Errorf("example.com should be valid: %v", err)
-	}
-
-	// Test with localhost - should be blocked
-	if err := validateHost("localhost"); err == nil {
-		t.Error("localhost should be blocked")
-	}
-
-	// Test with invalid domain - should not error (let HTTP client handle it)
-	if err := validateHost("this-domain-definitely-does-not-exist-12345.invalid"); err != nil {
-		t.Errorf("unresolvable domains should be allowed for HTTP client to handle: %v", err)
-	}
-}
+// Scheme validation, localhost/private-IP classification, and host resolution
+// are now provided and unit-tested by github.com/richardwooding/ssrfguard. The
+// table tests above (TestValidateFeedURL, TestSanitizeFeedURLs) and the
+// bypass-attempt test below exercise the delegated behavior end-to-end.
 
 // Security test for potential bypass attempts
 func TestSecurityBypassAttempts(t *testing.T) {


### PR DESCRIPTION
Replaces the in-repo URL/SSRF validation internals with the newly extracted [**ssrfguard**](https://github.com/richardwooding/ssrfguard) library (v0.1.0). Follows the same extract-and-adopt pattern as [#127](https://github.com/richardwooding/feed-mcp/pull/127) (hostrate).

## Changes
- `ValidateFeedURL` now delegates to `ssrfguard.Guard.ValidateURL`, mapping ssrfguard's sentinel errors back to this package's existing `Err*` vars so `errors.Is` in the enhanced error reporting (and any external callers) keep working.
- Removed `validateScheme`, `isLocalhost`, `isPrivateIP`, `validateHost` and their dedicated unit tests — that logic now lives in (and is tested by) ssrfguard.
- **Public API unchanged**: `ValidateFeedURL`, `SanitizeFeedURLs`, and the `Err*` vars are preserved; behavior is preserved (scheme allowlist, loopback/private/link-local blocking, unresolvable-host pass-through). ssrfguard additionally classifies the unspecified address (`0.0.0.0`/`::`).
- Net **−218 lines**.

## Not in this PR (deliberate)
ssrfguard's headline feature is a **dial-time** `net.Dialer.Control` guard that's safe against DNS rebinding. Wiring that into the store's HTTP client is a good follow-up, but it would block the loopback-bound `httptest` servers the suite relies on, so it's kept separate.

## Verification
- `go build ./...`, `go vet ./...`, full `go test ./...` (incl. BDD + fuzz seeds) — all pass.
- golangci-lint **v2.12.2** — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)