### PR TITLE
fix(model): sanitize host in GenerateFeedID to avoid unsafe ID chars

### DIFF
--- a/model/feed_id.go
+++ b/model/feed_id.go
@@ -17,6 +17,10 @@ func GenerateFeedID(feedURL string) string {
 	if parsedURL, err := url.Parse(feedURL); err == nil {
 		// Create a slug-like ID from the host and path
 		slug := strings.ToLower(parsedURL.Host)
+		// Sanitize the host: keep only characters that are safe in an identifier.
+		// Hosts legitimately contain dots, hyphens, underscores, colons (ports),
+		// and brackets (IPv6); anything else (e.g. non-ASCII, "!") is replaced.
+		slug = regexp.MustCompile(`[^a-z0-9.\-_:\[\]]`).ReplaceAllString(slug, "-")
 		if parsedURL.Path != "" && parsedURL.Path != "/" {
 			// Clean the path and append to host
 			path := strings.Trim(parsedURL.Path, "/")

--- a/model/testdata/fuzz/FuzzGenerateFeedID/bb7a96ca77e652c5
+++ b/model/testdata/fuzz/FuzzGenerateFeedID/bb7a96ca77e652c5
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("//!")


### PR DESCRIPTION
## Summary

The **Fuzz Testing** workflow has been failing on `main` (runs [27486669966](https://github.com/richardwooding/feed-mcp/actions/runs/27486669966), [27081074375](https://github.com/richardwooding/feed-mcp/actions/runs/27081074375)).

`FuzzGenerateFeedID` discovered the input `"//!"`, which `url.Parse` treats as a protocol-relative URL with `Host = "!"`. `GenerateFeedID` only sanitized the URL **path** via its regex — the host was lowercased and passed through untouched — so the resulting ID was `"!"`, violating the fuzz invariant that IDs only contain safe identifier characters.

```
feed_id_fuzz_test.go:127: GenerateFeedID returned ID with unexpected character '!': "!" (input: "//!")
```

## Fix

- Apply the same character-class filter to the host, keeping characters hosts legitimately use (`.`, `-`, `_`, `:` for ports, `[` `]` for IPv6) and replacing anything else with `-`.
- Add the failing input `"//!"` as a regression corpus entry under `model/testdata/fuzz/FuzzGenerateFeedID/`, so it runs on every `go test`.

## Testing

- `go test ./model/` ✅ (includes new regression seed)
- `go test -fuzz=FuzzGenerateFeedID -fuzztime=30s` — 3.4M executions, no failures ✅
- `go build ./...` ✅
- `golangci-lint run model/` — 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)