### PR TITLE
feat(mcpb): build Anthropic MCP Bundles (.mcpb) for every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,8 @@
 
 version: 2
 
+project_name: feed-mcp
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -16,7 +18,10 @@ before:
     - go generate ./...
 
 builds:
-  - env:
+  - id: feed-mcp
+    main: .
+    binary: feed-mcp
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -27,9 +32,23 @@ builds:
       - arm64
     ldflags:
       - -X main.version={{.Version}}
+    hooks:
+      # After each binary is built, pack it into an Anthropic MCP Bundle
+      # (.mcpb) for Claude Desktop. Runs once per target with that target's
+      # binary path/os/arch; each .mcpb filename is unique so parallel targets
+      # don't collide. The packer is pure Go (no Node), so this works on any host.
+      post:
+        - cmd: >-
+            go run ./tools/mcpb pack
+            -binary {{ .Path }}
+            -os {{ .Os }}
+            -arch {{ .Arch }}
+            -version {{ .Version }}
+            -out dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.mcpb
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -41,7 +60,8 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 changelog:
   sort: asc
@@ -51,7 +71,8 @@ changelog:
       - "^test:"
 
 kos:
-  - repositories: [ghcr.io/richardwooding/feed-mcp]
+  - build: feed-mcp
+    repositories: [ghcr.io/richardwooding/feed-mcp]
     tags:
       - "{{.Version}}"
       - latest
@@ -60,3 +81,30 @@ kos:
     platforms:
       - linux/amd64
       - linux/arm64
+
+# Homebrew cask published to the user's tap.
+homebrew_casks:
+  - name: feed-mcp
+    binaries:
+      - feed-mcp
+    directory: Casks
+    homepage: "https://github.com/richardwooding/feed-mcp"
+    description: "MCP server that fetches RSS/Atom/JSON feeds and serves them to AI assistants"
+    license: "MIT"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/feed-mcp"]
+          end
+    repository:
+      owner: richardwooding
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+
+release:
+  prerelease: auto
+  # Attach the MCP Bundles produced by the build post-hook to this same release.
+  extra_files:
+    - glob: dist/*.mcpb

--- a/README.md
+++ b/README.md
@@ -211,6 +211,34 @@ See [docs/ADVANCED.md](docs/ADVANCED.md) for details.
 
 ## Alternative Installation Methods
 
+### MCP Bundle (Claude Desktop, one-click)
+
+Every [release](https://github.com/richardwooding/feed-mcp/releases) attaches **MCP Bundles**
+(`.mcpb`) — one per platform. Download the bundle matching your OS and architecture (e.g.
+`feed-mcp_<version>_darwin_arm64.mcpb`) and open it with Claude Desktop to install — no Docker
+or Go toolchain required. The bundle's settings screen lets you set feed URLs, the per-feed
+request timeout, and the cache expiration. Feeds are optional at install time: runtime feed
+management is enabled, so you can also add feeds later with the `add_feed` tool.
+
+### Homebrew
+
+```bash
+brew install richardwooding/tap/feed-mcp
+```
+
+Then configure Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "feed-mcp": {
+      "command": "feed-mcp",
+      "args": ["run", "https://techcrunch.com/feed/"]
+    }
+  }
+}
+```
+
 ### Go Install
 
 If you have Go installed:
@@ -341,6 +369,34 @@ By default, localhost and private IP feeds are blocked for security. To enable:
 - **[ADVANCED.md](docs/ADVANCED.md)** — Dynamic feed management, MCP Resources, intelligent prompts
 - **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** — Technical details, architecture, development guide
 - **[CLAUDE.md](CLAUDE.md)** — Instructions for Claude Code when working with this codebase
+
+## Releasing
+
+Pushing a `vX.Y.Z` tag triggers the release workflow, which uses GoReleaser to:
+
+- build binaries for linux/darwin/windows (amd64 + arm64),
+- pack each binary into an **MCP Bundle** (`.mcpb`) and attach all six to the release,
+- build and push a multi-arch OCI image to GHCR with ko,
+- publish a Homebrew cask to [richardwooding/homebrew-tap](https://github.com/richardwooding/homebrew-tap).
+
+The Homebrew step needs a `HOMEBREW_TAP_GITHUB_TOKEN` repo secret with write access to the tap.
+
+### MCP Bundles
+
+`tools/mcpb` is a small, dependency-free (Go stdlib) packer that zips the server binary and a
+generated `manifest.json` into a `.mcpb`. GoReleaser invokes it per build target, but you can
+build a bundle for your current platform locally (no Node required):
+
+```bash
+go build -o feed-mcp .
+go run ./tools/mcpb pack -version dev   # writes dist/feed-mcp_dev_<os>_<arch>.mcpb
+```
+
+A full local dry run of the release pipeline (skips publishing):
+
+```bash
+goreleaser release --snapshot --clean
+```
 
 ## Contributing
 

--- a/tools/mcpb/main.go
+++ b/tools/mcpb/main.go
@@ -28,6 +28,15 @@ const (
 	displayName = "Feed MCP"
 	authorName  = "Richard Wooding"
 	description = "MCP server that fetches RSS/Atom/JSON feeds and serves them to AI assistants"
+
+	// osWindows is the Go GOOS value for Windows; platformWin32 is the
+	// corresponding manifest platform token (Node's process.platform).
+	osWindows     = "windows"
+	platformWin32 = "win32"
+
+	// userConfigTypeString is the MCP Bundle user_config field type used for
+	// every field this packer emits.
+	userConfigTypeString = "string"
 )
 
 func main() {
@@ -44,7 +53,7 @@ func main() {
 func pack(argv []string) error {
 	fs := flag.NewFlagSet("pack", flag.ContinueOnError)
 	defaultBinary := "./" + projectName
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		defaultBinary += ".exe"
 	}
 	var (
@@ -68,7 +77,7 @@ func pack(argv []string) error {
 	if err := m.validate(); err != nil {
 		return err
 	}
-	if err := writeBundle(outPath, m, *binary, binaryName(*goos)); err != nil {
+	if err := writeBundle(outPath, &m, *binary, binaryName(*goos)); err != nil {
 		return err
 	}
 	fmt.Printf("mcpb: wrote %s\n", outPath)
@@ -77,7 +86,7 @@ func pack(argv []string) error {
 
 // binaryName is the server binary's name inside the bundle for the target OS.
 func binaryName(goos string) string {
-	if goos == "windows" {
+	if goos == osWindows {
 		return projectName + ".exe"
 	}
 	return projectName
@@ -86,8 +95,8 @@ func binaryName(goos string) string {
 // manifestPlatform maps a Go GOOS to the manifest platform token (Node's
 // process.platform): windows -> win32, others unchanged.
 func manifestPlatform(goos string) string {
-	if goos == "windows" {
-		return "win32"
+	if goos == osWindows {
+		return platformWin32
 	}
 	return goos
 }
@@ -129,20 +138,20 @@ func buildManifest(goos, version string) Manifest {
 		},
 		UserConfig: map[string]UserConfigField{
 			"feeds": {
-				Type:        "string",
+				Type:        userConfigTypeString,
 				Title:       "Feed URLs",
 				Description: "RSS/Atom/JSON feed URLs to load at startup (you can also add feeds at runtime)",
 				Multiple:    true,
 				Required:    false,
 			},
 			"timeout": {
-				Type:        "string",
+				Type:        userConfigTypeString,
 				Title:       "Request timeout",
 				Description: "Per-feed fetch timeout (Go duration, e.g. 30s)",
 				Default:     "30s",
 			},
 			"expire_after": {
-				Type:        "string",
+				Type:        userConfigTypeString,
 				Title:       "Cache expiration",
 				Description: "How long feeds stay cached (Go duration, e.g. 1h)",
 				Default:     "1h",
@@ -152,9 +161,9 @@ func buildManifest(goos, version string) Manifest {
 	}
 	// On Windows the whole bundle already targets .exe; a win32 override makes
 	// the intent explicit and matches the manifest spec's binary example.
-	if goos == "windows" {
+	if goos == osWindows {
 		m.Server.PlatformOverrides = map[string]PlatformOverride{
-			"win32": {Command: cmd},
+			platformWin32: {Command: cmd},
 		}
 	}
 	return m
@@ -162,10 +171,12 @@ func buildManifest(goos, version string) Manifest {
 
 // writeBundle creates the .mcpb zip: manifest.json at the root and the binary at
 // server/<binName> with an executable mode bit.
-func writeBundle(outPath string, m Manifest, binarySrc, binName string) error {
-	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+func writeBundle(outPath string, m *Manifest, binarySrc, binName string) error {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o750); err != nil {
 		return err
 	}
+	// #nosec G304 -- outPath is a build-tool output path supplied on the command
+	// line by the release pipeline, not untrusted input.
 	f, err := os.Create(outPath)
 	if err != nil {
 		return err
@@ -191,6 +202,8 @@ func writeBundle(outPath string, m Manifest, binarySrc, binName string) error {
 	if err != nil {
 		return err
 	}
+	// #nosec G304 -- binarySrc is the compiled binary path passed by the release
+	// pipeline, not untrusted input.
 	src, err := os.Open(binarySrc)
 	if err != nil {
 		return fmt.Errorf("open binary: %w", err)

--- a/tools/mcpb/main.go
+++ b/tools/mcpb/main.go
@@ -1,0 +1,207 @@
+// Command mcpb packs the feed-mcp binary into an Anthropic MCP Bundle (.mcpb) —
+// a zip archive containing a manifest.json at the root and the server binary
+// under server/. It is a small, dependency-free (stdlib-only) alternative to
+// the Node @anthropic-ai/mcpb CLI, so a bundle can be built on any OS with just
+// the Go toolchain.
+//
+// Usage:
+//
+//	go run ./tools/mcpb pack [-binary path] [-os GOOS] [-arch GOARCH] [-version v] [-out file.mcpb]
+//
+// One .mcpb targets a single OS+arch (the manifest format selects a binary by OS
+// only, never architecture), so a release emits one bundle per platform.
+package main
+
+import (
+	"archive/zip"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	projectName = "feed-mcp"
+	displayName = "Feed MCP"
+	authorName  = "Richard Wooding"
+	description = "MCP server that fetches RSS/Atom/JSON feeds and serves them to AI assistants"
+)
+
+func main() {
+	if len(os.Args) < 2 || os.Args[1] != "pack" {
+		fmt.Fprintln(os.Stderr, "usage: mcpb pack [-binary path] [-os GOOS] [-arch GOARCH] [-version v] [-out file.mcpb]")
+		os.Exit(2)
+	}
+	if err := pack(os.Args[2:]); err != nil {
+		fmt.Fprintln(os.Stderr, "mcpb: "+err.Error())
+		os.Exit(1)
+	}
+}
+
+func pack(argv []string) error {
+	fs := flag.NewFlagSet("pack", flag.ContinueOnError)
+	defaultBinary := "./" + projectName
+	if runtime.GOOS == "windows" {
+		defaultBinary += ".exe"
+	}
+	var (
+		binary  = fs.String("binary", defaultBinary, "path to the compiled server binary to bundle")
+		goos    = fs.String("os", runtime.GOOS, "target OS (GOOS): linux, darwin or windows")
+		goarch  = fs.String("arch", runtime.GOARCH, "target architecture (GOARCH); used only in the output filename")
+		version = fs.String("version", "dev", "bundle version (a leading \"v\" is stripped)")
+		out     = fs.String("out", "", "output .mcpb path (default dist/<name>_<version>_<os>_<arch>.mcpb)")
+	)
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	ver := strings.TrimPrefix(*version, "v")
+	outPath := *out
+	if outPath == "" {
+		outPath = filepath.Join("dist", fmt.Sprintf("%s_%s_%s_%s.mcpb", projectName, ver, *goos, *goarch))
+	}
+
+	m := buildManifest(*goos, ver)
+	if err := m.validate(); err != nil {
+		return err
+	}
+	if err := writeBundle(outPath, m, *binary, binaryName(*goos)); err != nil {
+		return err
+	}
+	fmt.Printf("mcpb: wrote %s\n", outPath)
+	return nil
+}
+
+// binaryName is the server binary's name inside the bundle for the target OS.
+func binaryName(goos string) string {
+	if goos == "windows" {
+		return projectName + ".exe"
+	}
+	return projectName
+}
+
+// manifestPlatform maps a Go GOOS to the manifest platform token (Node's
+// process.platform): windows -> win32, others unchanged.
+func manifestPlatform(goos string) string {
+	if goos == "windows" {
+		return "win32"
+	}
+	return goos
+}
+
+func buildManifest(goos, version string) Manifest {
+	binName := binaryName(goos)
+	entry := "server/" + binName
+	// The command must be an absolute path; ${__dirname} expands to the
+	// installed bundle directory at runtime. A relative command (e.g.
+	// "server/...") is not resolved against the bundle dir and fails to spawn.
+	cmd := "${__dirname}/" + entry
+
+	m := Manifest{
+		ManifestVersion: "0.3",
+		Name:            projectName,
+		DisplayName:     displayName,
+		Version:         version,
+		Description:     description,
+		Author:          Author{Name: authorName},
+		Server: Server{
+			Type:       "binary",
+			EntryPoint: entry,
+			MCPConfig: MCPConfig{
+				Command: cmd,
+				// feed-mcp's "run" requires feeds, --opml, or
+				// --allow-runtime-feeds to start. Enabling runtime feeds lets
+				// the bundle start with zero configured feeds (users add them
+				// in chat). ${user_config.feeds} is a multi-value field, so it
+				// must come last — it expands to zero or more positional args.
+				Args: []string{
+					"run",
+					"--transport", "stdio",
+					"--allow-runtime-feeds",
+					"--timeout", "${user_config.timeout}",
+					"--expire-after", "${user_config.expire_after}",
+					"${user_config.feeds}",
+				},
+			},
+		},
+		UserConfig: map[string]UserConfigField{
+			"feeds": {
+				Type:        "string",
+				Title:       "Feed URLs",
+				Description: "RSS/Atom/JSON feed URLs to load at startup (you can also add feeds at runtime)",
+				Multiple:    true,
+				Required:    false,
+			},
+			"timeout": {
+				Type:        "string",
+				Title:       "Request timeout",
+				Description: "Per-feed fetch timeout (Go duration, e.g. 30s)",
+				Default:     "30s",
+			},
+			"expire_after": {
+				Type:        "string",
+				Title:       "Cache expiration",
+				Description: "How long feeds stay cached (Go duration, e.g. 1h)",
+				Default:     "1h",
+			},
+		},
+		Compatibility: &Compatibility{Platforms: []string{manifestPlatform(goos)}},
+	}
+	// On Windows the whole bundle already targets .exe; a win32 override makes
+	// the intent explicit and matches the manifest spec's binary example.
+	if goos == "windows" {
+		m.Server.PlatformOverrides = map[string]PlatformOverride{
+			"win32": {Command: cmd},
+		}
+	}
+	return m
+}
+
+// writeBundle creates the .mcpb zip: manifest.json at the root and the binary at
+// server/<binName> with an executable mode bit.
+func writeBundle(outPath string, m Manifest, binarySrc, binName string) error {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+
+	mw, err := zw.Create("manifest.json")
+	if err != nil {
+		return err
+	}
+	if err := m.writeJSON(mw); err != nil {
+		return err
+	}
+
+	// server/<binName> — forward slashes are required by archive/zip on every
+	// host OS, which keeps Windows-built bundles valid. Mode 0755 so the
+	// extracted binary stays executable on macOS/Linux.
+	hdr := &zip.FileHeader{Name: "server/" + binName, Method: zip.Deflate}
+	hdr.SetMode(0o755)
+	bw, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return err
+	}
+	src, err := os.Open(binarySrc)
+	if err != nil {
+		return fmt.Errorf("open binary: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := io.Copy(bw, src); err != nil {
+		return fmt.Errorf("copy binary: %w", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/tools/mcpb/main_test.go
+++ b/tools/mcpb/main_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBuildManifestUnix checks the manifest for a non-Windows target: a
+// ${__dirname}-prefixed command, the "run" subcommand first in args, the
+// multi-value feeds field last, and a platform token equal to the GOOS.
+func TestBuildManifestUnix(t *testing.T) {
+	m := buildManifest("darwin", "1.2.3")
+	if err := m.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if m.Server.MCPConfig.Command != "${__dirname}/server/feed-mcp" {
+		t.Errorf("command = %q, want ${__dirname}/server/feed-mcp", m.Server.MCPConfig.Command)
+	}
+	args := m.Server.MCPConfig.Args
+	if len(args) == 0 || args[0] != "run" {
+		t.Errorf("args[0] = %v, want \"run\"", args)
+	}
+	if got := args[len(args)-1]; got != "${user_config.feeds}" {
+		t.Errorf("last arg = %q, want ${user_config.feeds} (multi-value must be last)", got)
+	}
+	feeds, ok := m.UserConfig["feeds"]
+	if !ok || !feeds.Multiple {
+		t.Errorf("feeds field = %+v, want present with Multiple=true", feeds)
+	}
+	if got := m.Compatibility.Platforms; len(got) != 1 || got[0] != "darwin" {
+		t.Errorf("platforms = %v, want [darwin]", got)
+	}
+	if m.Server.PlatformOverrides != nil {
+		t.Errorf("unexpected platform_overrides on a unix target: %v", m.Server.PlatformOverrides)
+	}
+}
+
+// TestBuildManifestWindows checks the Windows-specific bits: a .exe entry
+// point, the win32 platform token, and a win32 override.
+func TestBuildManifestWindows(t *testing.T) {
+	m := buildManifest("windows", "v0.9.0")
+	if m.Server.EntryPoint != "server/feed-mcp.exe" {
+		t.Errorf("entry_point = %q, want server/feed-mcp.exe", m.Server.EntryPoint)
+	}
+	if got := m.Compatibility.Platforms; len(got) != 1 || got[0] != "win32" {
+		t.Errorf("platforms = %v, want [win32]", got)
+	}
+	ov, ok := m.Server.PlatformOverrides["win32"]
+	if !ok || ov.Command != "${__dirname}/server/feed-mcp.exe" {
+		t.Errorf("win32 override = %+v, want command ${__dirname}/server/feed-mcp.exe", ov)
+	}
+}
+
+// TestWriteBundle packs a fake binary and confirms the .mcpb zip holds a valid
+// manifest.json at the root and the server binary under server/.
+func TestWriteBundle(t *testing.T) {
+	dir := t.TempDir()
+	binSrc := filepath.Join(dir, "feed-mcp")
+	if err := os.WriteFile(binSrc, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "out.mcpb")
+
+	m := buildManifest("linux", "1.0.0")
+	if err := writeBundle(out, m, binSrc, binaryName("linux")); err != nil {
+		t.Fatalf("writeBundle: %v", err)
+	}
+
+	zr, err := zip.OpenReader(out)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	names := map[string]bool{}
+	for _, f := range zr.File {
+		names[f.Name] = true
+		if f.Name == "manifest.json" {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(rc); err != nil {
+				t.Fatal(err)
+			}
+			_ = rc.Close()
+			var decoded Manifest
+			if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+				t.Fatalf("manifest.json is not valid JSON: %v", err)
+			}
+		}
+	}
+	if !names["manifest.json"] {
+		t.Error("bundle missing manifest.json at root")
+	}
+	if !names["server/feed-mcp"] {
+		t.Error("bundle missing server/feed-mcp")
+	}
+}

--- a/tools/mcpb/main_test.go
+++ b/tools/mcpb/main_test.go
@@ -66,7 +66,7 @@ func TestWriteBundle(t *testing.T) {
 	out := filepath.Join(dir, "out.mcpb")
 
 	m := buildManifest("linux", "1.0.0")
-	if err := writeBundle(out, m, binSrc, binaryName("linux")); err != nil {
+	if err := writeBundle(out, &m, binSrc, binaryName("linux")); err != nil {
 		t.Fatalf("writeBundle: %v", err)
 	}
 

--- a/tools/mcpb/manifest.go
+++ b/tools/mcpb/manifest.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Manifest is the subset of the MCP Bundle manifest.json (manifest_version
+// "0.3") that this packer emits. See https://github.com/anthropics/mcpb.
+type Manifest struct {
+	ManifestVersion string                     `json:"manifest_version"`
+	Name            string                     `json:"name"`
+	DisplayName     string                     `json:"display_name,omitempty"`
+	Version         string                     `json:"version"`
+	Description     string                     `json:"description"`
+	Author          Author                     `json:"author"`
+	Server          Server                     `json:"server"`
+	UserConfig      map[string]UserConfigField `json:"user_config,omitempty"`
+	Compatibility   *Compatibility             `json:"compatibility,omitempty"`
+}
+
+type Author struct {
+	Name string `json:"name"`
+}
+
+type Server struct {
+	Type              string                      `json:"type"`
+	EntryPoint        string                      `json:"entry_point"`
+	MCPConfig         MCPConfig                   `json:"mcp_config"`
+	PlatformOverrides map[string]PlatformOverride `json:"platform_overrides,omitempty"`
+}
+
+type MCPConfig struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+type PlatformOverride struct {
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+type UserConfigField struct {
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Sensitive   bool   `json:"sensitive,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+	Multiple    bool   `json:"multiple,omitempty"`
+	Default     string `json:"default,omitempty"`
+}
+
+type Compatibility struct {
+	Platforms []string `json:"platforms,omitempty"`
+}
+
+// validate checks the fields the MCP Bundle spec marks as required. The Node
+// CLI would do this against a JSON schema; here we fail fast on empties.
+func (m Manifest) validate() error {
+	missing := func(name, val string) error {
+		if val == "" {
+			return fmt.Errorf("manifest: %s is required", name)
+		}
+		return nil
+	}
+	for _, e := range []error{
+		missing("manifest_version", m.ManifestVersion),
+		missing("name", m.Name),
+		missing("version", m.Version),
+		missing("description", m.Description),
+		missing("author.name", m.Author.Name),
+		missing("server.type", m.Server.Type),
+		missing("server.entry_point", m.Server.EntryPoint),
+		missing("server.mcp_config.command", m.Server.MCPConfig.Command),
+	} {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+func (m Manifest) writeJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(m)
+}

--- a/tools/mcpb/manifest.go
+++ b/tools/mcpb/manifest.go
@@ -59,7 +59,7 @@ type Compatibility struct {
 
 // validate checks the fields the MCP Bundle spec marks as required. The Node
 // CLI would do this against a JSON schema; here we fail fast on empties.
-func (m Manifest) validate() error {
+func (m *Manifest) validate() error {
 	missing := func(name, val string) error {
 		if val == "" {
 			return fmt.Errorf("manifest: %s is required", name)
@@ -83,7 +83,7 @@ func (m Manifest) validate() error {
 	return nil
 }
 
-func (m Manifest) writeJSON(w io.Writer) error {
+func (m *Manifest) writeJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(m)


### PR DESCRIPTION
## Summary

Replicates the MCP Bundle work recently done in `capetown-opendata-mcp` so every `feed-mcp` release ships a one-click Claude Desktop install, and adds a Homebrew cask.

- **`tools/mcpb/`** — a pure-Go (stdlib-only, no Node) packer that zips the server binary and a generated `manifest.json` (manifest_version `0.3`) into a `.mcpb`. Keeps the `${__dirname}` command-path handling and the Windows `win32` override from the capetown pattern.
- **GoReleaser** — a build post-hook packs one `.mcpb` per OS+arch (6 total); `release.extra_files` attaches them to the GitHub release; `kos` now references the named build.
- **Homebrew cask** — published to `richardwooding/homebrew-tap` with the macOS quarantine-removal post-install hook.
- Modernized the deprecated `archives.format` syntax so `goreleaser check` is clean.
- README: MCP Bundle + Homebrew install sections and a Releasing section.

### Bundle design (differs from capetown)

`feed-mcp`'s `run` requires feed URLs, `--opml`, or `--allow-runtime-feeds` to start, and feeds are positional args. So the bundle always passes `--allow-runtime-feeds` (starts with zero feeds; users add them via the `add_feed` tool) and exposes user config:

- `feeds` — multi-value, expands to positional args (listed last)
- `timeout` (default `30s`), `expire_after` (default `1h`)

## Prerequisite

The Homebrew step needs the `HOMEBREW_TAP_GITHUB_TOKEN` repo secret (write access to the tap). This is wired into `release.yml`.

## Verification

- `go run ./tools/mcpb pack` produces a valid bundle; manifest inspected for both unix (`darwin`) and `windows` (win32 override, `.exe` entry).
- Bundled args start the server over stdio (initialize responds; no "no feeds specified" error) with empty feeds.
- `goreleaser release --snapshot --clean` produced all 6 `.mcpb` files + archives + the Homebrew cask (ko step needs Docker, unrelated).
- New unit tests in `tools/mcpb/main_test.go`; `gofmt`/`go vet`/`go build`/`go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)