### PR TITLE
ci: enable baseline mode on the review gate

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -20,3 +20,4 @@ jobs:
         uses: richardwooding/file-search-on@main
         with:
           base: origin/${{ github.base_ref }}
+          baseline: "true"


### PR DESCRIPTION
Flip the review gate to `baseline: true` so it only fails on complexity new/worsened vs the PR base (file-search-on v0.117.0 ships the flag). Direct push blocked by branch protection, so this comes as a PR.