### PR TITLE
fix(model): stop fuzz tests hanging on DNS lookups

### DIFF
--- a/model/main_test.go
+++ b/model/main_test.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"testing"
+)
+
+// TestMain makes the model package's tests hermetic with respect to DNS.
+//
+// ValidateFeedURL delegates to ssrfguard, which resolves named hosts via
+// net.LookupIP with no timeout or context. Under `go test -fuzz` that is a
+// liability: the fuzzer synthesizes arbitrary hostnames, each one triggering a
+// real DNS lookup, and a slow or unreachable resolver (as in CI) stalls a worker
+// long enough for the fuzzing engine to report "fuzzing process hung or
+// terminated unexpectedly" — the failures seen in the weekly Fuzz Testing job
+// for FuzzValidateFeedURL and FuzzSanitizeFeedURLs.
+//
+// Pointing the default resolver at a dialer that fails immediately makes every
+// lookup return at once. ssrfguard treats an unresolvable host as allowed (the
+// dial-time guard would still catch a rebind), so this matches the existing unit
+// tests, none of which assert that a named host resolves to a blocked address.
+func TestMain(m *testing.M) {
+	net.DefaultResolver.PreferGo = true
+	net.DefaultResolver.Dial = func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("dns lookups are disabled in tests")
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Problem

The weekly **Fuzz Testing** workflow has been failing on two targets in `model/`:

- `FuzzValidateFeedURL`
- `FuzzSanitizeFeedURLs`

Both fail with:

```
--- FAIL: FuzzValidateFeedURL
    fuzzing process hung or terminated unexpectedly while minimizing: EOF
```

## Root cause

Both fuzz targets call `ValidateFeedURL`, which delegates to `ssrfguard.ValidateURL`. For a **named** host (not a literal IP), ssrfguard resolves it via `net.LookupIP` with no timeout or context:

```go
ips, err := net.LookupIP(hostname) // model -> ssrfguard validateHost
```

The fuzzer synthesizes arbitrary hostnames, so every iteration can trigger a real DNS lookup. In CI the resolver is slow/unreachable, so a worker stalls — the run logs show the exec rate pinned at `0/sec` for ~30s — long enough for the fuzzing engine to declare the process hung. ssrfguard v0.1.0 exposes no resolver/timeout injection point.

## Fix

Add a `TestMain` to the `model` package that points `net.DefaultResolver` at a fail-fast dialer, so every lookup returns immediately. ssrfguard treats an unresolvable host as *allowed* (the dial-time guard still catches rebinds), which matches the existing unit tests — none assert that a named host resolves to a blocked address. Literal IPs and `localhost` are handled before any lookup, so private-IP/SSRF coverage is unchanged.

## Verification

- `make lint` → 0 issues
- `go test ./model/` → pass
- Both previously-hanging fuzzers run clean for 20s at **100k+ execs/sec** with no stalls (was ~200/sec with 30s DNS stalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)