### PR TITLE
refactor(model): adopt ssrfguard v0.2.0 context + resolver API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/richardwooding/hostrate v0.1.0
-	github.com/richardwooding/ssrfguard v0.1.0
+	github.com/richardwooding/ssrfguard v0.2.0
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/richardwooding/hostrate v0.1.0 h1:oRlKmj+2UVKxV3QhQBhSsGi9cq8uXIqtCGpw6kMWnBI=
 github.com/richardwooding/hostrate v0.1.0/go.mod h1:pwdl6/mK9Cm0+mkJoZYTK1E37Q9OnTfeJD1fY/VBnzc=
-github.com/richardwooding/ssrfguard v0.1.0 h1:fv0X+eCMX81eHGgaYobCn1awLIF9dyRmrNO92PEGOdg=
-github.com/richardwooding/ssrfguard v0.1.0/go.mod h1:l26en+xGOtuFaRcpYqXkaCC2QdWggOyCw+DM5RzQpJQ=
+github.com/richardwooding/ssrfguard v0.2.0 h1:pryqh3ebL6BaZSPdWcHWb6A2yzkN+EZn//zhZpPixsM=
+github.com/richardwooding/ssrfguard v0.2.0/go.mod h1:l26en+xGOtuFaRcpYqXkaCC2QdWggOyCw+DM5RzQpJQ=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/model/main_test.go
+++ b/model/main_test.go
@@ -10,22 +10,27 @@ import (
 
 // TestMain makes the model package's tests hermetic with respect to DNS.
 //
-// ValidateFeedURL delegates to ssrfguard, which resolves named hosts via
-// net.LookupIP with no timeout or context. Under `go test -fuzz` that is a
-// liability: the fuzzer synthesizes arbitrary hostnames, each one triggering a
-// real DNS lookup, and a slow or unreachable resolver (as in CI) stalls a worker
-// long enough for the fuzzing engine to report "fuzzing process hung or
-// terminated unexpectedly" — the failures seen in the weekly Fuzz Testing job
-// for FuzzValidateFeedURL and FuzzSanitizeFeedURLs.
+// ValidateFeedURL resolves named hosts through ssrfguard to check them against
+// blocked ranges. Under `go test -fuzz` that is a liability: the fuzzer
+// synthesizes arbitrary hostnames, each one triggering a real DNS lookup, and a
+// slow or unreachable resolver (as in CI) stalls a worker long enough for the
+// fuzzing engine to report "fuzzing process hung or terminated unexpectedly" —
+// the failures once seen in the weekly Fuzz Testing job for FuzzValidateFeedURL
+// and FuzzSanitizeFeedURLs.
 //
-// Pointing the default resolver at a dialer that fails immediately makes every
-// lookup return at once. ssrfguard treats an unresolvable host as allowed (the
-// dial-time guard would still catch a rebind), so this matches the existing unit
-// tests, none of which assert that a named host resolves to a blocked address.
+// Substitute the package resolver (injected into ssrfguard via WithResolver)
+// with one whose Dial fails immediately, so every lookup returns at once.
+// ssrfguard treats an unresolvable host as allowed (the dial-time guard would
+// still catch a rebind), so this matches the existing unit tests, none of which
+// assert that a named host resolves to a blocked address. This is scoped to the
+// package's own resolver rather than mutating the process-wide
+// net.DefaultResolver.
 func TestMain(m *testing.M) {
-	net.DefaultResolver.PreferGo = true
-	net.DefaultResolver.Dial = func(context.Context, string, string) (net.Conn, error) {
-		return nil, errors.New("dns lookups are disabled in tests")
+	resolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("dns lookups are disabled in tests")
+		},
 	}
 	os.Exit(m.Run())
 }

--- a/model/url_validation.go
+++ b/model/url_validation.go
@@ -1,12 +1,26 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
+	"time"
 
 	"github.com/richardwooding/ssrfguard"
 )
+
+// resolver resolves named feed hosts during URL validation. It is a package
+// variable so tests can substitute a hermetic resolver that fails fast instead
+// of performing real DNS lookups; production leaves it as net.DefaultResolver.
+var resolver = net.DefaultResolver
+
+// validateResolveTimeout bounds DNS resolution during URL validation. ssrfguard
+// resolves named hosts to check them against blocked ranges; without a deadline
+// a slow or unreachable resolver would stall validation — notably at startup,
+// when every configured feed URL is sanitized.
+const validateResolveTimeout = 5 * time.Second
 
 // URL validation errors. These remain the package's public sentinels (matched
 // with errors.Is by enhanced error reporting) and are mapped from the
@@ -24,9 +38,17 @@ var (
 // (unless allowPrivateIPs is set) blocking of private, loopback, link-local, and
 // metadata addresses — via github.com/richardwooding/ssrfguard, returning this
 // package's sentinel errors so callers can match them with errors.Is.
+//
+// DNS resolution of named hosts is bounded by validateResolveTimeout so a slow
+// or unreachable resolver cannot stall validation.
 func ValidateFeedURL(rawURL string, allowPrivateIPs bool) error {
-	guard := ssrfguard.New(ssrfguard.WithAllowPrivate(allowPrivateIPs))
-	return mapSSRFError(guard.ValidateURL(rawURL))
+	ctx, cancel := context.WithTimeout(context.Background(), validateResolveTimeout)
+	defer cancel()
+	guard := ssrfguard.New(
+		ssrfguard.WithAllowPrivate(allowPrivateIPs),
+		ssrfguard.WithResolver(resolver),
+	)
+	return mapSSRFError(guard.ValidateURLContext(ctx, rawURL))
 }
 
 // mapSSRFError translates ssrfguard sentinel errors into this package's


### PR DESCRIPTION
Follow-up to #138, using the API added in [ssrfguard v0.2.0](https://github.com/richardwooding/ssrfguard/releases/tag/v0.2.0).

## Changes

- **Bump** `github.com/richardwooding/ssrfguard` v0.1.0 → v0.2.0.
- **Bounded resolution (production fix).** `ValidateFeedURL` now resolves named hosts through `guard.ValidateURLContext` with a 5s deadline. Previously resolution went through `net.LookupIP` with no timeout, so a slow or unreachable DNS server could stall validation — notably at startup, where every configured feed URL is sanitized in a loop.
- **Injectable resolver (test seam).** The resolver ssrfguard uses is now a `model` package variable wired in via `WithResolver`. `TestMain` substitutes a fail-fast resolver, **replacing the earlier workaround** (from #137) that mutated the process-wide `net.DefaultResolver`. This is scoped to the package's own resolver instead of a global side effect.

## Why

#137 stopped the weekly Fuzz Testing job hanging on real DNS by mutating `net.DefaultResolver` in `TestMain` — effective but blunt. v0.2.0 added `WithResolver` and `ValidateURLContext` specifically so this could be done cleanly, and so production validation could be given a deadline.

## Verification

- Behavior unchanged for production callers: default resolver, and an unresolvable host is still allowed (the dial-time guard from #138 catches a later rebind).
- `go test ./...`, `go vet`, `golangci-lint` all clean.
- `FuzzValidateFeedURL` stays hermetic at ~65k execs/sec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)