### PR TITLE
fix(store): guard feeds/circuitBreakers against concurrent access (#142)

### DIFF
--- a/store/dynamic_feeds.go
+++ b/store/dynamic_feeds.go
@@ -137,8 +137,8 @@ func (ds *DynamicStore) initializeStartupFeedMetadata() {
 		source = mcpserver.FeedSourceOPML
 	}
 
-	for feedID := range ds.feeds {
-		ds.feedMetadata[feedID] = &DynamicFeedMetadata{
+	for _, entry := range ds.feedEntries() {
+		ds.feedMetadata[entry.id] = &DynamicFeedMetadata{
 			AddedAt: time.Now(), // Approximate startup time
 			Source:  source,
 			Status:  statusActive,
@@ -165,9 +165,10 @@ func (ds *DynamicStore) AddFeed(ctx context.Context, config mcpserver.FeedConfig
 	ds.dynamicMutex.Lock()
 	defer ds.dynamicMutex.Unlock()
 
-	// Check if feed already exists (ds.feeds contains all feeds including dynamic ones)
-	for _, url := range ds.feeds {
-		if url == config.URL {
+	// Check if feed already exists (the feeds map contains all feeds, including
+	// dynamic ones).
+	for _, entry := range ds.feedEntries() {
+		if entry.url == config.URL {
 			return nil, model.NewFeedError(model.ErrorTypeValidation, fmt.Sprintf("feed with URL %s already exists", config.URL)).
 				WithOperation("add_feed").
 				WithComponent("dynamic_store")
@@ -177,8 +178,9 @@ func (ds *DynamicStore) AddFeed(ctx context.Context, config mcpserver.FeedConfig
 	// Generate feed ID
 	feedID := model.GenerateFeedID(config.URL)
 
-	// Add circuit breaker if enabled
-	if ds.circuitBreakers != nil {
+	// Build a circuit breaker if circuit breaking is enabled.
+	var cb *gobreaker.CircuitBreaker
+	if ds.hasCircuitBreakers() {
 		settings := gobreaker.Settings{
 			Name:        fmt.Sprintf("feed-%s", config.URL),
 			MaxRequests: ds.config.CircuitBreakerMaxRequests,
@@ -188,12 +190,13 @@ func (ds *DynamicStore) AddFeed(ctx context.Context, config mcpserver.FeedConfig
 				return counts.ConsecutiveFailures >= ds.config.CircuitBreakerFailureThreshold
 			},
 		}
-		ds.circuitBreakers[config.URL] = gobreaker.NewCircuitBreaker(settings)
+		cb = gobreaker.NewCircuitBreaker(settings)
 	}
 
-	// Add to dynamic feeds
+	// Register the feed (and its breaker) in the base store, and record it as a
+	// dynamic feed.
+	ds.putFeed(feedID, config.URL, cb)
 	ds.dynamicFeeds[feedID] = config.URL
-	ds.feeds[feedID] = config.URL
 
 	// Create metadata
 	metadata := &DynamicFeedMetadata{
@@ -246,7 +249,7 @@ func (ds *DynamicStore) RemoveFeed(ctx context.Context, feedID string) (*mcpserv
 	ds.dynamicMutex.Lock()
 	defer ds.dynamicMutex.Unlock()
 
-	url, exists := ds.feeds[feedID]
+	url, exists := ds.feedURL(feedID)
 	if !exists {
 		return nil, model.NewFeedError(model.ErrorTypeValidation, fmt.Sprintf("feed with ID %s not found", feedID)).
 			WithOperation("remove_feed").
@@ -268,15 +271,10 @@ func (ds *DynamicStore) RemoveFeed(ctx context.Context, feedID string) (*mcpserv
 		itemCount = len(feed.Items)
 	}
 
-	// Remove from maps
-	delete(ds.feeds, feedID)
+	// Remove from the base store (feed + circuit breaker) and the dynamic maps.
+	ds.deleteFeed(feedID, url)
 	delete(ds.dynamicFeeds, feedID)
 	delete(ds.feedMetadata, feedID)
-
-	// Remove circuit breaker
-	if ds.circuitBreakers != nil {
-		delete(ds.circuitBreakers, url)
-	}
 
 	// Clear from cache
 	_ = ds.feedCacheManager.Delete(ctx, url) // Cache deletion errors are not critical
@@ -296,15 +294,13 @@ func (ds *DynamicStore) RemoveFeed(ctx context.Context, feedID string) (*mcpserv
 
 // RemoveFeedByURL implements DynamicFeedManager.RemoveFeedByURL
 func (ds *DynamicStore) RemoveFeedByURL(ctx context.Context, url string) (*mcpserver.RemovedFeedInfo, error) {
-	ds.dynamicMutex.RLock()
 	var feedID string
-	for id, feedURL := range ds.feeds {
-		if feedURL == url {
-			feedID = id
+	for _, entry := range ds.feedEntries() {
+		if entry.url == url {
+			feedID = entry.id
 			break
 		}
 	}
-	ds.dynamicMutex.RUnlock()
 
 	if feedID == "" {
 		return nil, model.NewFeedError(model.ErrorTypeValidation, fmt.Sprintf("feed with URL %s not found", url)).
@@ -320,9 +316,11 @@ func (ds *DynamicStore) ListManagedFeeds(ctx context.Context) ([]mcpserver.Manag
 	ds.dynamicMutex.RLock()
 	defer ds.dynamicMutex.RUnlock()
 
-	feeds := make([]mcpserver.ManagedFeedInfo, 0, len(ds.feeds))
+	entries := ds.feedEntries()
+	feeds := make([]mcpserver.ManagedFeedInfo, 0, len(entries))
 
-	for feedID, url := range ds.feeds {
+	for _, entry := range entries {
+		feedID, url := entry.id, entry.url
 		metadata := ds.feedMetadata[feedID]
 		if metadata == nil {
 			// Fallback metadata for missing entries
@@ -378,9 +376,7 @@ func (ds *DynamicStore) ListManagedFeeds(ctx context.Context) ([]mcpserver.Manag
 
 // RefreshFeed implements DynamicFeedManager.RefreshFeed
 func (ds *DynamicStore) RefreshFeed(ctx context.Context, feedID string) (*mcpserver.RefreshFeedInfo, error) {
-	ds.dynamicMutex.RLock()
-	url, exists := ds.feeds[feedID]
-	ds.dynamicMutex.RUnlock()
+	url, exists := ds.feedURL(feedID)
 
 	if !exists {
 		return &mcpserver.RefreshFeedInfo{

--- a/store/dynamic_feeds.go
+++ b/store/dynamic_feeds.go
@@ -313,61 +313,69 @@ func (ds *DynamicStore) RemoveFeedByURL(ctx context.Context, url string) (*mcpse
 
 // ListManagedFeeds implements DynamicFeedManager.ListManagedFeeds
 func (ds *DynamicStore) ListManagedFeeds(ctx context.Context) ([]mcpserver.ManagedFeedInfo, error) {
+	// Snapshot the feeds and their metadata under the locks, then release them
+	// before the per-feed network fetches below — holding dynamicMutex across
+	// checkFeedCache would block AddFeed/RemoveFeed for the duration of every
+	// cache load. Locks are taken dynamicMutex (outer) → feedsMu (inner, via
+	// feedEntries), matching the ordering used elsewhere.
+	type feedSnapshot struct {
+		id   string
+		url  string
+		meta DynamicFeedMetadata
+	}
 	ds.dynamicMutex.RLock()
-	defer ds.dynamicMutex.RUnlock()
-
 	entries := ds.feedEntries()
-	feeds := make([]mcpserver.ManagedFeedInfo, 0, len(entries))
-
+	snapshots := make([]feedSnapshot, 0, len(entries))
 	for _, entry := range entries {
-		feedID, url := entry.id, entry.url
-		metadata := ds.feedMetadata[feedID]
-		if metadata == nil {
-			// Fallback metadata for missing entries
-			metadata = &DynamicFeedMetadata{
-				AddedAt: time.Now(),
-				Source:  mcpserver.FeedSourceStartup,
-				Status:  "active",
-			}
+		meta := DynamicFeedMetadata{
+			AddedAt: time.Now(),
+			Source:  mcpserver.FeedSourceStartup,
+			Status:  "active",
 		}
+		if m := ds.feedMetadata[entry.id]; m != nil {
+			meta = *m
+		}
+		snapshots = append(snapshots, feedSnapshot{id: entry.id, url: entry.url, meta: meta})
+	}
+	ds.dynamicMutex.RUnlock()
 
-		// Get current item count and update status
-		cacheInfo := ds.checkFeedCache(ctx, url)
+	feeds := make([]mcpserver.ManagedFeedInfo, 0, len(snapshots))
+	for i := range snapshots {
+		snap := &snapshots[i]
+		// Get current item count and status (network fetch; no lock held).
+		cacheInfo := ds.checkFeedCache(ctx, snap.url)
 		itemCount := cacheInfo.ItemCount
-		var status string
+		status := cacheInfo.Status
 		var lastError string
 		var lastFetched time.Time
 
 		if cacheInfo.Found {
-			status = cacheInfo.Status
-			lastError = ""
 			lastFetched = cacheInfo.LastFetched
 		} else {
-			status = cacheInfo.Status
 			lastError = cacheInfo.LastError
-			lastFetched = metadata.LastFetched // Keep original if cache fetch failed
+			lastFetched = snap.meta.LastFetched // Keep original if cache fetch failed
 		}
 
 		// Title falls back to the freshly-fetched cacheInfo.Title when metadata
 		// is blank — startup/OPML feeds seed empty titles (see #114 lazy init)
 		// and rely on the first list_managed_feeds call to surface the real title.
-		title := metadata.Title
+		title := snap.meta.Title
 		if title == "" && cacheInfo.Found {
 			title = cacheInfo.Title
 		}
 
 		feeds = append(feeds, mcpserver.ManagedFeedInfo{
-			FeedID:      feedID,
-			URL:         url,
+			FeedID:      snap.id,
+			URL:         snap.url,
 			Title:       title,
-			Category:    metadata.Category,
-			Description: metadata.Description,
+			Category:    snap.meta.Category,
+			Description: snap.meta.Description,
 			Status:      status,
 			LastFetched: lastFetched,
 			LastError:   lastError,
 			ItemCount:   itemCount,
-			AddedAt:     metadata.AddedAt,
-			Source:      string(metadata.Source),
+			AddedAt:     snap.meta.AddedAt,
+			Source:      string(snap.meta.Source),
 		})
 	}
 

--- a/store/dynamic_feeds_race_test.go
+++ b/store/dynamic_feeds_race_test.go
@@ -12,6 +12,34 @@ import (
 	"github.com/richardwooding/feed-mcp/mcpserver"
 )
 
+// raceReader hammers the inherited base-Store read paths until stop is closed.
+func raceReader(ctx context.Context, ds *DynamicStore, stop <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		_, _ = ds.GetAllFeeds(ctx)
+		_, _ = ds.ListManagedFeeds(ctx)
+	}
+}
+
+// raceWriter adds, reads, and removes feeds, mutating the shared maps.
+func raceWriter(ctx context.Context, ds *DynamicStore, baseURL string, worker int, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for j := range 30 {
+		url := fmt.Sprintf("%s/feed-%d-%d", baseURL, worker, j)
+		info, err := ds.AddFeed(ctx, mcpserver.FeedConfig{URL: url})
+		if err != nil || info == nil {
+			continue
+		}
+		_, _ = ds.GetFeedAndItems(ctx, info.FeedID)
+		_, _ = ds.RemoveFeed(ctx, info.FeedID)
+	}
+}
+
 // TestDynamicStore_ConcurrentAccessNoRace exercises the data race fixed in #142:
 // DynamicStore.AddFeed/RemoveFeed mutate the base Store's feeds and
 // circuitBreakers maps while the (inherited) GetAllFeeds/GetFeedAndItems read
@@ -40,38 +68,13 @@ func TestDynamicStore_ConcurrentAccessNoRace(t *testing.T) {
 	stop := make(chan struct{})
 	var readers, writers sync.WaitGroup
 
-	// Readers: hammer the inherited base-Store read paths.
 	for range 4 {
 		readers.Add(1)
-		go func() {
-			defer readers.Done()
-			for {
-				select {
-				case <-stop:
-					return
-				default:
-				}
-				_, _ = ds.GetAllFeeds(ctx)
-				_, _ = ds.ListManagedFeeds(ctx)
-			}
-		}()
+		go raceReader(ctx, ds, stop, &readers)
 	}
-
-	// Writers: add, read, and remove feeds, mutating the shared maps.
 	for w := range 4 {
 		writers.Add(1)
-		go func(w int) {
-			defer writers.Done()
-			for j := range 30 {
-				url := fmt.Sprintf("%s/feed-%d-%d", srv.URL, w, j)
-				info, err := ds.AddFeed(ctx, mcpserver.FeedConfig{URL: url})
-				if err != nil || info == nil {
-					continue
-				}
-				_, _ = ds.GetFeedAndItems(ctx, info.FeedID)
-				_, _ = ds.RemoveFeed(ctx, info.FeedID)
-			}
-		}(w)
+		go raceWriter(ctx, ds, srv.URL, w, &writers)
 	}
 
 	writers.Wait()

--- a/store/dynamic_feeds_race_test.go
+++ b/store/dynamic_feeds_race_test.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/feed-mcp/mcpserver"
+)
+
+// TestDynamicStore_ConcurrentAccessNoRace exercises the data race fixed in #142:
+// DynamicStore.AddFeed/RemoveFeed mutate the base Store's feeds and
+// circuitBreakers maps while the (inherited) GetAllFeeds/GetFeedAndItems read
+// them. Run with -race; before the fix this triggered "concurrent map read and
+// map write" and could fatally crash the server.
+func TestDynamicStore_ConcurrentAccessNoRace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(`<rss version="2.0"><channel><title>race</title></channel></rss>`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Feeds:             []string{srv.URL + "/seed"},
+		AllowPrivateIPs:   true, // dial-time guard must allow the loopback test server
+		RequestsPerSecond: 1000, // avoid rate-limit throttling during the test
+		BurstCapacity:     1000,
+		ExpireAfter:       time.Hour,
+	}
+	ds, err := NewDynamicStore(&cfg, true)
+	if err != nil {
+		t.Fatalf("NewDynamicStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	stop := make(chan struct{})
+	var readers, writers sync.WaitGroup
+
+	// Readers: hammer the inherited base-Store read paths.
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _ = ds.GetAllFeeds(ctx)
+				_, _ = ds.ListManagedFeeds(ctx)
+			}
+		}()
+	}
+
+	// Writers: add, read, and remove feeds, mutating the shared maps.
+	for w := range 4 {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for j := range 30 {
+				url := fmt.Sprintf("%s/feed-%d-%d", srv.URL, w, j)
+				info, err := ds.AddFeed(ctx, mcpserver.FeedConfig{URL: url})
+				if err != nil || info == nil {
+					continue
+				}
+				_, _ = ds.GetFeedAndItems(ctx, info.FeedID)
+				_, _ = ds.RemoveFeed(ctx, info.FeedID)
+			}
+		}(w)
+	}
+
+	writers.Wait()
+	close(stop)
+	readers.Wait()
+}

--- a/store/dynamic_feeds_race_test.go
+++ b/store/dynamic_feeds_race_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,8 +27,10 @@ func raceReader(ctx context.Context, ds *DynamicStore, stop <-chan struct{}, wg 
 	}
 }
 
-// raceWriter adds, reads, and removes feeds, mutating the shared maps.
-func raceWriter(ctx context.Context, ds *DynamicStore, baseURL string, worker int, wg *sync.WaitGroup) {
+// raceWriter adds, reads, and removes feeds, mutating the shared maps. It counts
+// successful adds so the test can confirm it actually exercised concurrent
+// writes (rather than silently no-op'ing if every AddFeed failed).
+func raceWriter(ctx context.Context, ds *DynamicStore, baseURL string, worker int, wg *sync.WaitGroup, added *atomic.Int64) {
 	defer wg.Done()
 	for j := range 30 {
 		url := fmt.Sprintf("%s/feed-%d-%d", baseURL, worker, j)
@@ -35,6 +38,7 @@ func raceWriter(ctx context.Context, ds *DynamicStore, baseURL string, worker in
 		if err != nil || info == nil {
 			continue
 		}
+		added.Add(1)
 		_, _ = ds.GetFeedAndItems(ctx, info.FeedID)
 		_, _ = ds.RemoveFeed(ctx, info.FeedID)
 	}
@@ -64,9 +68,14 @@ func TestDynamicStore_ConcurrentAccessNoRace(t *testing.T) {
 		t.Fatalf("NewDynamicStore failed: %v", err)
 	}
 
-	ctx := context.Background()
+	// A bounded context so a regression that hangs a fetch fails the test
+	// instead of stalling the whole suite.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	stop := make(chan struct{})
 	var readers, writers sync.WaitGroup
+	var added atomic.Int64
 
 	for range 4 {
 		readers.Add(1)
@@ -74,10 +83,14 @@ func TestDynamicStore_ConcurrentAccessNoRace(t *testing.T) {
 	}
 	for w := range 4 {
 		writers.Add(1)
-		go raceWriter(ctx, ds, srv.URL, w, &writers)
+		go raceWriter(ctx, ds, srv.URL, w, &writers, &added)
 	}
 
 	writers.Wait()
 	close(stop)
 	readers.Wait()
+
+	if added.Load() == 0 {
+		t.Fatal("no AddFeed succeeded; the test did not exercise concurrent map writes")
+	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -79,6 +79,77 @@ type Store struct {
 	circuitBreakers  map[string]*gobreaker.CircuitBreaker
 	retryMetrics     *RetryMetrics
 	metricsMutex     sync.RWMutex
+	// feedsMu guards the feeds and circuitBreakers maps. The base Store only
+	// reads them after construction, but DynamicStore mutates them at runtime
+	// (add_feed / remove_feed) concurrently with reads here, so every access to
+	// either map — base or dynamic — must hold this lock. It is held only around
+	// the map operations themselves, never across a network fetch.
+	feedsMu sync.RWMutex
+}
+
+// feedEntry pairs a feed's ID with its URL for snapshotting the feeds map.
+type feedEntry struct {
+	id  string
+	url string
+}
+
+// feedEntries returns a snapshot of the configured feeds, taken under the read
+// lock so iteration can proceed without holding the lock across network fetches.
+func (s *Store) feedEntries() []feedEntry {
+	s.feedsMu.RLock()
+	defer s.feedsMu.RUnlock()
+	entries := make([]feedEntry, 0, len(s.feeds))
+	for id, url := range s.feeds {
+		entries = append(entries, feedEntry{id: id, url: url})
+	}
+	return entries
+}
+
+// feedURL returns the URL for a feed ID under the read lock.
+func (s *Store) feedURL(id string) (string, bool) {
+	s.feedsMu.RLock()
+	defer s.feedsMu.RUnlock()
+	url, ok := s.feeds[id]
+	return url, ok
+}
+
+// hasCircuitBreakers reports whether circuit breakers are configured.
+func (s *Store) hasCircuitBreakers() bool {
+	s.feedsMu.RLock()
+	defer s.feedsMu.RUnlock()
+	return s.circuitBreakers != nil
+}
+
+// circuitBreaker returns the circuit breaker for a URL under the read lock.
+func (s *Store) circuitBreaker(url string) (*gobreaker.CircuitBreaker, bool) {
+	s.feedsMu.RLock()
+	defer s.feedsMu.RUnlock()
+	if s.circuitBreakers == nil {
+		return nil, false
+	}
+	cb, ok := s.circuitBreakers[url]
+	return cb, ok
+}
+
+// putFeed registers a feed (and, when configured, its circuit breaker) under the
+// write lock.
+func (s *Store) putFeed(id, url string, cb *gobreaker.CircuitBreaker) {
+	s.feedsMu.Lock()
+	defer s.feedsMu.Unlock()
+	s.feeds[id] = url
+	if cb != nil && s.circuitBreakers != nil {
+		s.circuitBreakers[url] = cb
+	}
+}
+
+// deleteFeed removes a feed and its circuit breaker under the write lock.
+func (s *Store) deleteFeed(id, url string) {
+	s.feedsMu.Lock()
+	defer s.feedsMu.Unlock()
+	delete(s.feeds, id)
+	if s.circuitBreakers != nil {
+		delete(s.circuitBreakers, url)
+	}
 }
 
 // newPooledTransport builds an *http.Transport with the given connection pool
@@ -381,7 +452,7 @@ func newStoreInternal(config Config) (*Store, error) {
 	}
 
 	s.feedCacheManager = cache.NewLoadable[*gofeed.Feed](
-		s.makeFeedLoader(&config, circuitBreakers, circuitBreakerEnabled),
+		s.makeFeedLoader(&config, circuitBreakerEnabled),
 		cache.New[*gofeed.Feed](ristrettoStore),
 	)
 
@@ -494,7 +565,6 @@ func buildCircuitBreakers(config *Config, enabled bool) map[string]*gobreaker.Ci
 // on demand, optionally guarded by a per-feed circuit breaker.
 func (s *Store) makeFeedLoader(
 	config *Config,
-	circuitBreakers map[string]*gobreaker.CircuitBreaker,
 	circuitBreakerEnabled bool,
 ) func(ctx context.Context, key any) (*gofeed.Feed, []store.Option, error) {
 	return func(ctx context.Context, key any) (*gofeed.Feed, []store.Option, error) {
@@ -515,7 +585,7 @@ func (s *Store) makeFeedLoader(
 
 		// Use circuit breaker if enabled and configured for this URL.
 		if circuitBreakerEnabled {
-			if cb, exists := circuitBreakers[url]; exists {
+			if cb, exists := s.circuitBreaker(url); exists {
 				feed, err := s.fetchWithCircuitBreaker(ctx, url, fp, config, cb)
 				if err != nil {
 					return nil, nil, err
@@ -567,10 +637,11 @@ func (s *Store) fetchWithCircuitBreaker(
 
 // GetAllFeeds returns all configured feeds with their current status
 func (s *Store) GetAllFeeds(ctx context.Context) ([]*model.FeedResult, error) {
-	results := make([]*model.FeedResult, len(s.feeds))
+	// Snapshot the feeds under the read lock so the fetches below don't hold it.
+	entries := s.feedEntries()
+	results := make([]*model.FeedResult, len(entries))
 	wg := &sync.WaitGroup{}
-	idx := 0
-	for id, url := range s.feeds {
+	for idx, entry := range entries {
 		wg.Add(1)
 		go func(idx int, id string, url string) {
 			defer wg.Done()
@@ -582,10 +653,8 @@ func (s *Store) GetAllFeeds(ctx context.Context) ([]*model.FeedResult, error) {
 			}
 
 			// Check circuit breaker state
-			if s.circuitBreakers != nil {
-				if cb, exists := s.circuitBreakers[url]; exists {
-					result.CircuitBreakerOpen = cb.State() == gobreaker.StateOpen
-				}
+			if cb, exists := s.circuitBreaker(url); exists {
+				result.CircuitBreakerOpen = cb.State() == gobreaker.StateOpen
 			}
 
 			if err != nil {
@@ -596,8 +665,7 @@ func (s *Store) GetAllFeeds(ctx context.Context) ([]*model.FeedResult, error) {
 			}
 
 			results[idx] = result
-		}(idx, id, url)
-		idx++
+		}(idx, entry.id, entry.url)
 	}
 	wg.Wait()
 	return results, nil
@@ -605,7 +673,7 @@ func (s *Store) GetAllFeeds(ctx context.Context) ([]*model.FeedResult, error) {
 
 // GetFeedAndItems returns a specific feed with all its items
 func (s *Store) GetFeedAndItems(ctx context.Context, id string) (*model.FeedAndItemsResult, error) {
-	if url, exists := s.feeds[id]; exists {
+	if url, exists := s.feedURL(id); exists {
 		feed, err := s.feedCacheManager.Get(ctx, url)
 
 		result := &model.FeedAndItemsResult{
@@ -614,10 +682,8 @@ func (s *Store) GetFeedAndItems(ctx context.Context, id string) (*model.FeedAndI
 		}
 
 		// Check circuit breaker state
-		if s.circuitBreakers != nil {
-			if cb, exists := s.circuitBreakers[url]; exists {
-				result.CircuitBreakerOpen = cb.State() == gobreaker.StateOpen
-			}
+		if cb, exists := s.circuitBreaker(url); exists {
+			result.CircuitBreakerOpen = cb.State() == gobreaker.StateOpen
 		}
 
 		if err != nil {


### PR DESCRIPTION
Fixes #142.

## Problem

`DynamicStore` embeds `*Store` and mutates the base `feeds` and `circuitBreakers` maps in `AddFeed`/`RemoveFeed` under `dynamicMutex`. But the inherited `Store.GetAllFeeds` / `GetFeedAndItems` — and the cache loader's circuit-breaker lookup — read those maps with **no lock**. Concurrent `add_feed`/`remove_feed` and feed reads is a data race that can fatally crash the server (`fatal error: concurrent map read and map write`). It's reachable in normal operation with `--allow-runtime-feeds`.

Flagged repeatedly by Gemini on #140; pre-existing (not introduced there).

## Fix

Add a dedicated `feedsMu sync.RWMutex` on the base `Store` that guards both maps, accessed only through small locked helpers:

- reads: `feedEntries()` (snapshot), `feedURL(id)`, `circuitBreaker(url)`, `hasCircuitBreakers()`
- writes: `putFeed(id, url, cb)`, `deleteFeed(id, url)`

Key points:
- **The lock is never held across a network fetch.** `GetAllFeeds` snapshots the feed list under the read lock, then fetches without it; circuit-breaker state is read via a brief `circuitBreaker(url)` call. The cache loader reads the breaker the same way instead of via a captured map.
- **All** access — base reads, the loader, and every `DynamicStore` read/write — now routes through these accessors.
- `dynamicMutex` still guards the `DynamicStore`-only maps (`dynamicFeeds`, `feedMetadata`). `DynamicStore` always acquires `dynamicMutex` before `feedsMu`, and base methods never acquire `dynamicMutex`, so there is no lock-ordering cycle.

## Tests

- New `TestDynamicStore_ConcurrentAccessNoRace` runs concurrent `AddFeed`/`GetFeedAndItems`/`RemoveFeed` against `GetAllFeeds`/`ListManagedFeeds`. It trips the race detector before this change and passes after.
- `go test -race ./...` is green across the module; `go vet` and `golangci-lint` clean.

Will release as **v2.6.2** after merge. (The related lock-held-across-fetch contention in `AddFeed` remains tracked in #141.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)