### PR TITLE
feat(site): add gloam GitHub Pages landing page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+# Deploy the gloam landing page in site/ to GitHub Pages.
+# For more information see: https://docs.github.com/en/pages/getting-started-with-github-pages
+
+name: Pages
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Allow one concurrent deployment; skip runs queued behind an in-progress one.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/gloam.css
+++ b/site/gloam.css
@@ -1,0 +1,183 @@
+/*!
+ * gloam.css — a dark-first, purple-accented, terminal-flavored design language.
+ * https://github.com/richardwooding/gloam · MIT
+ *
+ * Tokens are prefixed --gl-*, component classes gl-*, so it drops into any page
+ * without collisions. Dark is the default; light is served via
+ * prefers-color-scheme AND an explicit :root[data-theme="light"|"dark"] override.
+ */
+
+:root {
+  --gl-bg: #0d1117;
+  --gl-panel: #161b22;
+  --gl-panel-2: #1c2230;
+  --gl-border: #2a3038;
+  --gl-fg: #e6edf3;
+  --gl-muted: #9aa7b4;
+  --gl-faint: #6b7684;
+  --gl-accent: #a371f7;
+  --gl-accent-2: #bd93ff;
+  --gl-accent-ink: #f5efff;
+  --gl-green: #3fb950;
+  --gl-amber: #d29922;
+  --gl-radius: 14px;
+  --gl-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --gl-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --gl-maxw: 1080px;
+}
+
+/* Light palette: auto (system) … */
+@media (prefers-color-scheme: light) {
+  :root {
+    --gl-bg: #ffffff;
+    --gl-panel: #f6f8fa;
+    --gl-panel-2: #eef1f5;
+    --gl-border: #d8dee4;
+    --gl-fg: #1f2328;
+    --gl-muted: #59636e;
+    --gl-faint: #818b98;
+    --gl-accent: #7c3aed;
+    --gl-accent-2: #6d28d9;
+    --gl-accent-ink: #ffffff;
+    --gl-green: #1a7f37;
+    --gl-amber: #9a6700;
+  }
+}
+/* … and explicit override wins in both directions. */
+:root[data-theme="light"] {
+  --gl-bg: #ffffff; --gl-panel: #f6f8fa; --gl-panel-2: #eef1f5; --gl-border: #d8dee4;
+  --gl-fg: #1f2328; --gl-muted: #59636e; --gl-faint: #818b98;
+  --gl-accent: #7c3aed; --gl-accent-2: #6d28d9; --gl-accent-ink: #ffffff;
+  --gl-green: #1a7f37; --gl-amber: #9a6700;
+}
+:root[data-theme="dark"] {
+  --gl-bg: #0d1117; --gl-panel: #161b22; --gl-panel-2: #1c2230; --gl-border: #2a3038;
+  --gl-fg: #e6edf3; --gl-muted: #9aa7b4; --gl-faint: #6b7684;
+  --gl-accent: #a371f7; --gl-accent-2: #bd93ff; --gl-accent-ink: #f5efff;
+  --gl-green: #3fb950; --gl-amber: #d29922;
+}
+
+/* ---- base ---- */
+.gl-body, body.gl {
+  margin: 0;
+  background: var(--gl-bg);
+  color: var(--gl-fg);
+  font-family: var(--gl-sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+.gl a { color: var(--gl-accent-2); text-decoration: none; }
+.gl a:hover { text-decoration: underline; }
+.gl code, .gl kbd, .gl pre { font-family: var(--gl-mono); }
+.gl h1, .gl h2, .gl h3 { line-height: 1.2; letter-spacing: -0.02em; margin: 0; }
+
+.gl-wrap { max-width: var(--gl-maxw); margin: 0 auto; padding: 0 20px; }
+.gl-section { padding: 72px 0; border-top: 1px solid var(--gl-border); }
+.gl-eyebrow { color: var(--gl-accent-2); font-weight: 700; font-size: .8rem; letter-spacing: .08em; text-transform: uppercase; margin: 0 0 10px; }
+.gl-lede { color: var(--gl-muted); font-size: 1.05rem; max-width: 60ch; }
+.gl-hint { color: var(--gl-faint); font-size: .82rem; margin-top: 10px; }
+
+/* skip link */
+.gl-skip { position: absolute; left: -9999px; }
+.gl-skip:focus { left: 12px; top: 10px; z-index: 50; background: var(--gl-panel); color: var(--gl-fg); padding: 8px 12px; border-radius: 8px; }
+
+/* ---- nav ---- */
+.gl-nav { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(10px);
+  background: color-mix(in srgb, var(--gl-bg) 82%, transparent); border-bottom: 1px solid var(--gl-border); }
+.gl-nav .gl-wrap { display: flex; align-items: center; gap: 18px; height: 60px; }
+.gl-brand { display: flex; align-items: center; gap: 10px; font-weight: 700; color: var(--gl-fg); font-size: 1.05rem; }
+.gl-brand svg { display: block; }
+.gl-nav nav { margin-left: auto; display: flex; align-items: center; gap: 22px; }
+.gl-nav nav a { color: var(--gl-muted); font-weight: 600; font-size: .95rem; }
+.gl-nav nav a:hover { color: var(--gl-fg); text-decoration: none; }
+.gl-nav-toggle { display: none; margin-left: auto; background: var(--gl-panel); color: var(--gl-fg);
+  border: 1px solid var(--gl-border); border-radius: 8px; padding: 8px 10px; cursor: pointer; }
+
+/* ---- buttons ---- */
+.gl-btn { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; font-size: .95rem;
+  padding: 10px 16px; border-radius: 10px; border: 1px solid var(--gl-border); cursor: pointer; color: var(--gl-fg); background: transparent; }
+.gl-btn.primary { background: linear-gradient(180deg, var(--gl-accent), var(--gl-accent-2)); color: var(--gl-accent-ink); border-color: transparent; }
+.gl-btn.primary:hover { filter: brightness(1.07); text-decoration: none; }
+.gl-btn.ghost { background: var(--gl-panel); }
+.gl-btn.ghost:hover { border-color: var(--gl-accent); text-decoration: none; }
+
+/* ---- hero ---- */
+.gl-hero { padding: 84px 0 64px; }
+.gl-hero h1 { font-size: clamp(2.1rem, 5.2vw, 3.4rem); font-weight: 800; }
+.gl-grad { background: linear-gradient(90deg, var(--gl-accent-2), #e9d5ff); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.gl-hero p.sub { font-size: 1.2rem; color: var(--gl-muted); margin: 18px 0 28px; max-width: 56ch; }
+.gl-cta { display: flex; gap: 12px; flex-wrap: wrap; }
+.gl-hero-grid { display: grid; grid-template-columns: 1.05fr 1fr; gap: 44px; align-items: center; }
+@media (max-width: 860px) { .gl-hero-grid { grid-template-columns: 1fr; gap: 32px; } }
+
+/* ---- terminal ---- */
+.gl-term { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius); overflow: hidden;
+  box-shadow: 0 20px 50px -30px rgba(0,0,0,.7); }
+.gl-term .bar { display: flex; align-items: center; gap: 7px; padding: 11px 14px; background: var(--gl-panel-2); border-bottom: 1px solid var(--gl-border); }
+.gl-term .dot { width: 11px; height: 11px; border-radius: 50%; }
+.gl-term .bar .t { margin-left: 10px; color: var(--gl-faint); font: 600 .8rem/1 var(--gl-mono); }
+.gl-term pre { margin: 0; padding: 16px; overflow-x: auto; font-size: .82rem; line-height: 1.65; color: var(--gl-fg); }
+.gl-term .pr { color: var(--gl-accent-2); }
+.gl-term .hd { color: var(--gl-faint); }
+.gl-term .n { color: var(--gl-accent-2); font-weight: 700; }
+.gl-term .loc { color: var(--gl-muted); }
+.gl-term .ok { color: var(--gl-green); }
+.gl-term .warn { color: var(--gl-amber); }
+
+/* ---- pills / tabs ---- */
+.gl-badges { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 26px; }
+.gl-lang { font: 700 .72rem/1 var(--gl-mono); color: var(--gl-muted); background: var(--gl-panel);
+  border: 1px solid var(--gl-border); border-radius: 999px; padding: 7px 12px; cursor: pointer;
+  transition: color .12s, border-color .12s, background .12s; }
+.gl-lang:hover { color: var(--gl-fg); border-color: var(--gl-accent); }
+.gl-lang:focus-visible { outline: 2px solid var(--gl-accent); outline-offset: 2px; }
+.gl-lang[aria-selected="true"] { background: linear-gradient(180deg, var(--gl-accent), var(--gl-accent-2)); color: var(--gl-accent-ink); border-color: transparent; }
+
+/* ---- cards / grid ---- */
+.gl-grid { display: grid; gap: 18px; }
+.gl-grid.two { grid-template-columns: 1fr 1fr; }
+.gl-grid.feat { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 820px) { .gl-grid.feat { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .gl-grid.two, .gl-grid.feat { grid-template-columns: 1fr; } }
+.gl-card { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius); padding: 22px; }
+.gl-card h3 { font-size: 1.05rem; margin-bottom: 8px; display: flex; align-items: center; gap: 10px; }
+.gl-card p { color: var(--gl-muted); margin: 0; font-size: .95rem; }
+.gl-icon { width: 34px; height: 34px; flex: none; display: grid; place-items: center; border-radius: 9px;
+  background: color-mix(in srgb, var(--gl-accent) 18%, transparent); color: var(--gl-accent-2); }
+.gl-icon svg { width: 18px; height: 18px; }
+.gl-stat { font: 800 2rem/1 var(--gl-mono); color: var(--gl-accent-2); }
+
+/* ---- code blocks ---- */
+.gl-code { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius);
+  padding: 16px 18px; overflow-x: auto; font-size: .85rem; line-height: 1.6; margin: 0; }
+.gl-code .c { color: var(--gl-faint); }
+.gl-code .k { color: var(--gl-accent-2); }
+.gl-code .s { color: var(--gl-green); }
+.gl-split { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; align-items: start; }
+@media (max-width: 760px) { .gl-split { grid-template-columns: 1fr; } }
+
+/* ---- install snippets ---- */
+.gl-install { display: grid; gap: 14px; max-width: 760px; }
+.gl-snip { display: flex; align-items: center; gap: 12px; background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: 12px; padding: 6px 6px 6px 16px; }
+.gl-snip .lbl { font: 700 .72rem/1 var(--gl-mono); color: var(--gl-accent-2); text-transform: uppercase; letter-spacing: .05em; flex: none; width: 74px; }
+.gl-snip code { flex: 1; overflow-x: auto; white-space: nowrap; color: var(--gl-fg); font-size: .88rem; padding: 8px 0; }
+.gl-copy { flex: none; background: var(--gl-panel-2); color: var(--gl-muted); border: 1px solid var(--gl-border); border-radius: 8px; padding: 8px 12px; font: 700 .78rem/1 var(--gl-sans); cursor: pointer; }
+.gl-copy:hover { color: var(--gl-fg); border-color: var(--gl-accent); }
+.gl-copy.done { color: var(--gl-green); border-color: var(--gl-green); }
+
+/* ---- footer ---- */
+.gl-footer { border-top: 1px solid var(--gl-border); padding: 40px 0 60px; color: var(--gl-muted); }
+.gl-footer .gl-wrap { display: flex; flex-wrap: wrap; gap: 18px 28px; align-items: center; justify-content: space-between; }
+.gl-footer a { color: var(--gl-muted); font-weight: 600; font-size: .92rem; }
+.gl-footer a:hover { color: var(--gl-fg); }
+.gl-fnav { display: flex; flex-wrap: wrap; gap: 18px; }
+
+/* ---- mobile nav ---- */
+@media (max-width: 680px) {
+  .gl-nav nav { display: none; }
+  .gl-nav nav.open { display: flex; position: absolute; top: 60px; left: 0; right: 0; flex-direction: column; gap: 0;
+    background: var(--gl-bg); border-bottom: 1px solid var(--gl-border); padding: 8px 20px 16px; }
+  .gl-nav nav.open a { padding: 10px 0; }
+  .gl-nav nav.open .gl-btn { display: none; }
+  .gl-nav-toggle { display: block; }
+}

--- a/site/gloam.css
+++ b/site/gloam.css
@@ -101,6 +101,24 @@
 .gl-btn.ghost { background: var(--gl-panel); }
 .gl-btn.ghost:hover { border-color: var(--gl-accent); text-decoration: none; }
 
+/* ---- theme toggle ---- */
+.gl-theme-toggle { display: inline-grid; place-items: center; width: 38px; height: 38px; flex: none;
+  background: var(--gl-panel); color: var(--gl-fg); border: 1px solid var(--gl-border); border-radius: 10px; cursor: pointer; padding: 0; }
+.gl-theme-toggle:hover { border-color: var(--gl-accent); }
+.gl-theme-toggle:focus-visible { outline: 2px solid var(--gl-accent); outline-offset: 2px; }
+.gl-theme-toggle svg { width: 18px; height: 18px; display: block; }
+/* Icon reflects the active theme — CSS-only swap across system + forced themes. */
+.gl-theme-toggle .gl-sun { display: none; }
+.gl-theme-toggle .gl-moon { display: block; }
+@media (prefers-color-scheme: light) {
+  .gl-theme-toggle .gl-sun { display: block; }
+  .gl-theme-toggle .gl-moon { display: none; }
+}
+:root[data-theme="light"] .gl-theme-toggle .gl-sun { display: block; }
+:root[data-theme="light"] .gl-theme-toggle .gl-moon { display: none; }
+:root[data-theme="dark"] .gl-theme-toggle .gl-sun { display: none; }
+:root[data-theme="dark"] .gl-theme-toggle .gl-moon { display: block; }
+
 /* ---- hero ---- */
 .gl-hero { padding: 84px 0 64px; }
 .gl-hero h1 { font-size: clamp(2.1rem, 5.2vw, 3.4rem); font-weight: 800; }

--- a/site/gloam.js
+++ b/site/gloam.js
@@ -1,0 +1,82 @@
+/*!
+ * gloam.js — optional, dependency-free behaviors for the gloam design language.
+ * https://github.com/richardwooding/gloam · MIT
+ *
+ * Everything is data-attribute driven and no-ops when the elements are absent,
+ * so you can include it unconditionally. Runs on DOMContentLoaded.
+ *
+ *   Copy button:  <button class="gl-copy" data-gl-copy="snippetId">Copy</button>
+ *                 <code id="snippetId">…</code>
+ *   Tabs:         <button class="gl-lang" data-gl-tab="one" ...>One</button>
+ *                 container: <div data-gl-tabs>…buttons…</div>
+ *                 panels:    <div data-gl-panel="one">…</div>  (hidden unless selected)
+ *   Mobile nav:   <button data-gl-nav-toggle="navId">☰</button>  <nav id="navId">…</nav>
+ *   Year:         <span data-gl-year></span>
+ */
+(function () {
+  "use strict";
+  function ready(fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  }
+
+  ready(function () {
+    // Current year.
+    document.querySelectorAll("[data-gl-year]").forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+
+    // Copy-to-clipboard buttons.
+    document.querySelectorAll("[data-gl-copy]").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var target = document.getElementById(btn.getAttribute("data-gl-copy"));
+        if (!target) return;
+        var text = target.textContent;
+        function done() {
+          var old = btn.textContent;
+          btn.textContent = "Copied";
+          btn.classList.add("done");
+          setTimeout(function () { btn.textContent = old; btn.classList.remove("done"); }, 1400);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(fallback);
+        } else {
+          fallback();
+        }
+        function fallback() {
+          var ta = document.createElement("textarea");
+          ta.value = text; ta.style.position = "absolute"; ta.style.left = "-9999px";
+          document.body.appendChild(ta); ta.select();
+          try { document.execCommand("copy"); done(); } catch (e) { /* ignore */ }
+          document.body.removeChild(ta);
+        }
+      });
+    });
+
+    // Pill tabs: clicking [data-gl-tab=X] inside [data-gl-tabs] shows [data-gl-panel=X].
+    document.querySelectorAll("[data-gl-tabs]").forEach(function (group) {
+      var tabs = group.querySelectorAll("[data-gl-tab]");
+      function select(name) {
+        tabs.forEach(function (t) { t.setAttribute("aria-selected", String(t.getAttribute("data-gl-tab") === name)); });
+        document.querySelectorAll("[data-gl-panel]").forEach(function (p) {
+          p.hidden = p.getAttribute("data-gl-panel") !== name;
+        });
+      }
+      tabs.forEach(function (t) {
+        t.addEventListener("click", function () { select(t.getAttribute("data-gl-tab")); });
+      });
+      var initial = group.querySelector('[data-gl-tab][aria-selected="true"]') || tabs[0];
+      if (initial) select(initial.getAttribute("data-gl-tab"));
+    });
+
+    // Mobile nav toggle; closes when a link inside is tapped.
+    document.querySelectorAll("[data-gl-nav-toggle]").forEach(function (btn) {
+      var nav = document.getElementById(btn.getAttribute("data-gl-nav-toggle"));
+      if (!nav) return;
+      btn.addEventListener("click", function () { nav.classList.toggle("open"); });
+      nav.addEventListener("click", function (e) {
+        if (e.target.tagName === "A") nav.classList.remove("open");
+      });
+    });
+  });
+})();

--- a/site/gloam.js
+++ b/site/gloam.js
@@ -47,7 +47,8 @@
           var ta = document.createElement("textarea");
           ta.value = text; ta.style.position = "absolute"; ta.style.left = "-9999px";
           document.body.appendChild(ta); ta.select();
-          try { document.execCommand("copy"); done(); } catch (e) { /* ignore */ }
+          // Only signal success if the copy actually happened.
+          try { if (document.execCommand("copy")) done(); } catch (e) { /* ignore */ }
           document.body.removeChild(ta);
         }
       });
@@ -56,9 +57,12 @@
     // Pill tabs: clicking [data-gl-tab=X] inside [data-gl-tabs] shows [data-gl-panel=X].
     document.querySelectorAll("[data-gl-tabs]").forEach(function (group) {
       var tabs = group.querySelectorAll("[data-gl-tab]");
+      // Scope panels to this group's container so multiple tab groups on one
+      // page don't toggle each other's panels.
+      var container = group.parentElement || group.parentNode || document;
       function select(name) {
         tabs.forEach(function (t) { t.setAttribute("aria-selected", String(t.getAttribute("data-gl-tab") === name)); });
-        document.querySelectorAll("[data-gl-panel]").forEach(function (p) {
+        container.querySelectorAll("[data-gl-panel]").forEach(function (p) {
           p.hidden = p.getAttribute("data-gl-panel") !== name;
         });
       }
@@ -75,7 +79,8 @@
       if (!nav) return;
       btn.addEventListener("click", function () { nav.classList.toggle("open"); });
       nav.addEventListener("click", function (e) {
-        if (e.target.tagName === "A") nav.classList.remove("open");
+        // closest("a") so clicks on elements nested inside a link still close.
+        if (e.target.closest && e.target.closest("a")) nav.classList.remove("open");
       });
     });
   });

--- a/site/gloam.js
+++ b/site/gloam.js
@@ -11,6 +11,8 @@
  *                 container: <div data-gl-tabs>…buttons…</div>
  *                 panels:    <div data-gl-panel="one">…</div>  (hidden unless selected)
  *   Mobile nav:   <button data-gl-nav-toggle="navId">☰</button>  <nav id="navId">…</nav>
+ *   Theme toggle: <button data-gl-theme-toggle aria-label="Toggle color theme">…</button>
+ *                 flips light/dark on <html data-theme>, persisted in localStorage.
  *   Year:         <span data-gl-year></span>
  */
 (function () {
@@ -20,10 +22,44 @@
     else document.addEventListener("DOMContentLoaded", fn);
   }
 
+  // Effective theme: an explicit data-theme wins, else the system preference.
+  // (Reading the computed --gl-bg is unreliable — browsers serialize it as rgb().)
+  function isDark() {
+    var explicit = document.documentElement.getAttribute("data-theme");
+    if (explicit) return explicit === "dark";
+    return !window.matchMedia("(prefers-color-scheme: light)").matches;
+  }
+
+  // Restore a persisted theme as early as this script runs. For flash-free
+  // restore, also add this one-liner in <head> (runs before first paint):
+  //   <script>try{var t=localStorage.getItem("gl-theme");if(t)document.documentElement.setAttribute("data-theme",t)}catch(e){}</script>
+  try {
+    var savedTheme = localStorage.getItem("gl-theme");
+    if (savedTheme === "light" || savedTheme === "dark") {
+      document.documentElement.setAttribute("data-theme", savedTheme);
+    }
+  } catch (e) { /* ignore */ }
+
   ready(function () {
     // Current year.
     document.querySelectorAll("[data-gl-year]").forEach(function (el) {
       el.textContent = new Date().getFullYear();
+    });
+
+    // Theme toggle: flip light/dark, persist the choice, reflect it in aria-pressed.
+    var themeToggles = document.querySelectorAll("[data-gl-theme-toggle]");
+    function syncToggles() {
+      var dark = isDark();
+      themeToggles.forEach(function (b) { b.setAttribute("aria-pressed", String(dark)); });
+    }
+    syncToggles();
+    themeToggles.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var next = isDark() ? "light" : "dark";
+        document.documentElement.setAttribute("data-theme", next);
+        try { localStorage.setItem("gl-theme", next); } catch (e) { /* ignore */ }
+        syncToggles();
+      });
     });
 
     // Copy-to-clipboard buttons.
@@ -57,9 +93,15 @@
     // Pill tabs: clicking [data-gl-tab=X] inside [data-gl-tabs] shows [data-gl-panel=X].
     document.querySelectorAll("[data-gl-tabs]").forEach(function (group) {
       var tabs = group.querySelectorAll("[data-gl-tab]");
-      // Scope panels to this group's container so multiple tab groups on one
-      // page don't toggle each other's panels.
-      var container = group.parentElement || group.parentNode || document;
+      // Scope panels to the nearest ancestor that actually contains them, so
+      // multiple tab groups on a page don't toggle each other's panels — while
+      // still working when the group and its panels sit in sibling columns
+      // (e.g. hero pills in one column, terminal panels in the other).
+      var container = group.parentElement;
+      while (container && !container.querySelector("[data-gl-panel]")) {
+        container = container.parentElement;
+      }
+      if (!container) container = document;
       function select(name) {
         tabs.forEach(function (t) { t.setAttribute("aria-selected", String(t.getAttribute("data-gl-tab") === name)); });
         container.querySelectorAll("[data-gl-panel]").forEach(function (p) {

--- a/site/index.html
+++ b/site/index.html
@@ -77,12 +77,15 @@
             <span class="dot" style="background:#27c93f"></span>
             <span class="t">feed-mcp</span>
           </div>
-<pre><span class="pr">$</span> feed-mcp run https://techcrunch.com/feed/
-<span class="hd">STATUS   FEED             ITEMS</span>
-<span class="n">ok</span>       techcrunch       <span class="loc">20 items · cached 1h</span>
-<span class="n">ok</span>       the verge        <span class="loc">20 items · cached 1h</span>
-<span class="ok">ready</span>    stdio transport  <span class="loc">3 tools · 4 resources</span>
-<span class="warn">warn</span>     example.com      <span class="loc">circuit open · retrying</span></pre>
+<pre><span class="pr">$</span> feed-mcp run https://hnrss.org/frontpage
+<span class="pr">»</span> initialize   <span class="loc">RSS, Atom, and JSON Feed Server</span>
+<span class="pr">»</span> tools/list   <span class="loc">5 tools · 5 prompts</span>
+<span class="pr">»</span> tools/call <span class="n">all_syndication_feeds</span>
+{
+  <span class="hd">"id"</span>:         <span class="n">"hnrss.org-frontpage"</span>,
+  <span class="hd">"title"</span>:      <span class="n">"Hacker News: Front Page"</span>,
+  <span class="hd">"public_url"</span>: <span class="n">"https://hnrss.org/frontpage"</span>
+}</pre>
         </div>
       </div>
     </section>
@@ -232,8 +235,10 @@
             <h3 style="font-size:1.05rem;margin-bottom:6px">Tools</h3>
             <ul class="gl-panel-list">
               <li><code>all_syndication_feeds</code> — list every configured feed</li>
-              <li><code>get_syndication_feed_items</code> — paginated items with conservative defaults</li>
+              <li><code>get_syndication_feed_items</code> — paginated items, metadata-first</li>
               <li><code>fetch_link</code> — pull the full content of a specific article</li>
+              <li><code>merge_feeds</code> — aggregate feeds with dedup and sorting</li>
+              <li><code>export_feed_data</code> — export as JSON, CSV, OPML, RSS, or Atom</li>
               <li><code>add_feed</code> · <code>remove_feed</code> · <code>list_managed_feeds</code> — with <code>--allow-runtime-feeds</code></li>
             </ul>
           </div>
@@ -247,6 +252,7 @@
             </ul>
           </div>
         </div>
+        <p class="gl-hint">Five prompts ship too — <code>summarize_feeds</code>, <code>analyze_feed_trends</code>, <code>compare_sources</code>, <code>monitor_keywords</code>, and <code>generate_feed_report</code>.</p>
         <p class="gl-hint">Item reads default to metadata-only, <code>limit</code> 10 (max 20), to avoid overflowing the conversation context. Opt into <code>includeContent</code> / <code>includeImages</code> when you need more.</p>
       </div>
     </section>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,335 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>feed-mcp — Bring RSS feeds to Claude</title>
+  <meta name="description" content="feed-mcp is a Model Context Protocol server that lets Claude read RSS, Atom, and JSON feeds — with smart caching, rate limiting, circuit breakers, and SSRF protection.">
+  <meta property="og:title" content="feed-mcp — Bring RSS feeds to Claude">
+  <meta property="og:description" content="An MCP server that fetches RSS/Atom/JSON feeds and serves them to AI assistants.">
+  <meta property="og:type" content="website">
+  <link rel="stylesheet" href="gloam.css">
+  <style>
+    /* page-local extras, all derived from gloam tokens */
+    .gl-theme-toggle { background: var(--gl-panel); color: var(--gl-fg); border: 1px solid var(--gl-border);
+      border-radius: 8px; padding: 8px 10px; cursor: pointer; font: 600 .82rem/1 var(--gl-sans); }
+    .gl-theme-toggle:hover { border-color: var(--gl-accent); }
+    .gl-config { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius);
+      padding: 16px 18px; overflow-x: auto; font-size: .85rem; line-height: 1.6; margin: 0; font-family: var(--gl-mono); }
+    .gl-config .c { color: var(--gl-faint); }
+    .gl-config .k { color: var(--gl-accent-2); }
+    .gl-config .s { color: var(--gl-green); }
+    .gl-config .p { color: var(--gl-muted); }
+    .gl-panel-list { list-style: none; margin: 18px 0 0; padding: 0; display: grid; gap: 10px; }
+    .gl-panel-list li { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: 12px;
+      padding: 12px 16px; color: var(--gl-muted); font-size: .95rem; }
+    .gl-panel-list code { color: var(--gl-accent-2); font-size: .88rem; }
+    .gl-tab-wrap { margin-top: 18px; }
+    .gl-tab-wrap [data-gl-panel] { margin-top: 16px; }
+    .gl-two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; align-items: start; }
+    @media (max-width: 760px) { .gl-two-col { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body class="gl">
+  <a class="gl-skip" href="#main">Skip to content</a>
+
+  <header class="gl-nav">
+    <div class="gl-wrap">
+      <span class="gl-brand">
+        <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true">
+          <rect width="24" height="24" rx="6" fill="var(--gl-panel-2)"/>
+          <rect x="5" y="12" width="3.5" height="7" rx="1" fill="var(--gl-accent)"/>
+          <rect x="10.25" y="8" width="3.5" height="11" rx="1" fill="var(--gl-accent-2)"/>
+          <rect x="15.5" y="4" width="3.5" height="15" rx="1" fill="#d2b3ff"/>
+        </svg>
+        feed-mcp
+      </span>
+      <button class="gl-nav-toggle" aria-label="Toggle navigation" data-gl-nav-toggle="nav">☰</button>
+      <nav id="nav">
+        <a href="#features">Features</a>
+        <a href="#install">Install</a>
+        <a href="#surface">MCP Surface</a>
+        <a href="#resilience">Resilience</a>
+        <button class="gl-theme-toggle" id="theme" aria-label="Toggle color theme">◑ Theme</button>
+        <a class="gl-btn ghost" href="https://github.com/richardwooding/feed-mcp">GitHub ★</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- HERO -->
+    <section class="gl-hero">
+      <div class="gl-wrap gl-hero-grid">
+        <div>
+          <p class="gl-eyebrow">rss · atom · json · model context protocol</p>
+          <h1>Bring RSS feeds to <span class="gl-grad">Claude.</span></h1>
+          <p class="sub">feed-mcp is a Model Context Protocol server that lets AI assistants read RSS, Atom, and JSON feeds — so you can ask about the latest articles, get summaries, and stay updated without leaving your chat.</p>
+          <div class="gl-cta">
+            <a class="gl-btn primary" href="#install">Get started</a>
+            <a class="gl-btn ghost" href="https://github.com/richardwooding/feed-mcp">View on GitHub</a>
+          </div>
+          <p class="gl-hint">Docker · Homebrew · Go install · one-click MCP Bundle for Claude Desktop</p>
+        </div>
+        <div class="gl-term">
+          <div class="bar">
+            <span class="dot" style="background:#ff5f56"></span>
+            <span class="dot" style="background:#ffbd2e"></span>
+            <span class="dot" style="background:#27c93f"></span>
+            <span class="t">feed-mcp</span>
+          </div>
+<pre><span class="pr">$</span> feed-mcp run https://techcrunch.com/feed/
+<span class="hd">STATUS   FEED             ITEMS</span>
+<span class="n">ok</span>       techcrunch       <span class="loc">20 items · cached 1h</span>
+<span class="n">ok</span>       the verge        <span class="loc">20 items · cached 1h</span>
+<span class="ok">ready</span>    stdio transport  <span class="loc">3 tools · 4 resources</span>
+<span class="warn">warn</span>     example.com      <span class="loc">circuit open · retrying</span></pre>
+        </div>
+      </div>
+    </section>
+
+    <!-- FEATURES -->
+    <section id="features" class="gl-section">
+      <div class="gl-wrap">
+        <p class="gl-eyebrow">what you get</p>
+        <h2>A feed bridge built for AI conversations.</h2>
+        <p class="gl-lede" style="margin-top:12px">Two-pass reading keeps responses fast: Claude browses titles first, then fetches full content only for the articles you ask about.</p>
+        <div class="gl-grid feat" style="margin-top:28px">
+          <div class="gl-card">
+            <h3>
+              <span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1.5" fill="currentColor" stroke="none"/></svg></span>
+              Multiple formats
+            </h3>
+            <p>RSS, Atom, and JSON feeds — parsed through one consistent model your assistant can reason over.</p>
+          </div>
+          <div class="gl-card">
+            <h3>
+              <span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M5 21h14"/></svg></span>
+              Import from readers
+            </h3>
+            <p>Point it at an OPML file exported from Feedly, Inoreader, or NewsBlur and every feed comes along.</p>
+          </div>
+          <div class="gl-card">
+            <h3>
+              <span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8v4l3 2"/><circle cx="12" cy="12" r="9"/></svg></span>
+              Smart caching
+            </h3>
+            <p>In-memory cache keyed by feed URL, 1-hour default expiry — fresh enough, without hammering sources.</p>
+          </div>
+          <div class="gl-card">
+            <h3>
+              <span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L4 14h7l-1 8 9-12h-7z"/></svg></span>
+              Fast &amp; resilient
+            </h3>
+            <p>Per-host rate limiting, exponential-backoff retries, circuit breakers, and connection pooling built in.</p>
+          </div>
+          <div class="gl-card">
+            <h3>
+              <span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3l7 4v5c0 4-3 7-7 9-4-2-7-5-7-9V7z"/></svg></span>
+              Secure by default
+            </h3>
+            <p>SSRF protection via ssrfguard — HTTP(S) only, private IPs blocked, DNS-rebinding defeated at dial time.</p>
+          </div>
+          <div class="gl-card">
+            <h3>
+              <span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="12" rx="2"/><path d="M8 20h8M12 16v4"/></svg></span>
+              Easy deployment
+            </h3>
+            <p>Run over stdio for Claude Desktop, or Streamable HTTP for web and remote deployments.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- INSTALL -->
+    <section id="install" class="gl-section">
+      <div class="gl-wrap">
+        <p class="gl-eyebrow">get it running</p>
+        <h2>Install in a minute.</h2>
+        <p class="gl-lede" style="margin-top:12px">Pick your platform, then drop the config into Claude Desktop. Feeds are just arguments.</p>
+
+        <div class="gl-install" style="margin-top:26px">
+          <div class="gl-snip">
+            <span class="lbl">brew</span>
+            <code id="i-brew">brew install richardwooding/tap/feed-mcp</code>
+            <button class="gl-copy" data-gl-copy="i-brew">Copy</button>
+          </div>
+          <div class="gl-snip">
+            <span class="lbl">go</span>
+            <code id="i-go">go install github.com/richardwooding/feed-mcp@latest</code>
+            <button class="gl-copy" data-gl-copy="i-go">Copy</button>
+          </div>
+          <div class="gl-snip">
+            <span class="lbl">docker</span>
+            <code id="i-docker">docker run -i --rm ghcr.io/richardwooding/feed-mcp:latest run https://techcrunch.com/feed/</code>
+            <button class="gl-copy" data-gl-copy="i-docker">Copy</button>
+          </div>
+        </div>
+        <p class="gl-hint">Prefer Podman? Swap <code>docker</code> for <code>podman</code> — the arguments are identical. Or grab a one-click <code>.mcpb</code> MCP Bundle from the <a href="https://github.com/richardwooding/feed-mcp/releases">releases page</a>.</p>
+
+        <h3 style="margin-top:44px;font-size:1.15rem">Add it to Claude Desktop</h3>
+        <div class="gl-badges" role="tablist" aria-label="Choose install method" data-gl-tabs>
+          <button class="gl-lang" role="tab" data-gl-tab="docker" aria-selected="true">Docker</button>
+          <button class="gl-lang" role="tab" data-gl-tab="brew">Homebrew / Go</button>
+          <button class="gl-lang" role="tab" data-gl-tab="opml">OPML</button>
+        </div>
+
+        <div class="gl-tab-wrap">
+          <div data-gl-panel="docker">
+<pre class="gl-config"><span class="p">{</span>
+  <span class="k">"mcpServers"</span>: {
+    <span class="k">"feed-mcp"</span>: {
+      <span class="k">"command"</span>: <span class="s">"docker"</span>,
+      <span class="k">"args"</span>: [
+        <span class="s">"run"</span>, <span class="s">"-i"</span>, <span class="s">"--rm"</span>,
+        <span class="s">"ghcr.io/richardwooding/feed-mcp:latest"</span>,
+        <span class="s">"run"</span>,
+        <span class="s">"https://techcrunch.com/feed/"</span>,
+        <span class="s">"https://www.theverge.com/rss/index.xml"</span>
+      ]
+    }
+  }
+<span class="p">}</span></pre>
+          </div>
+          <div data-gl-panel="brew" hidden>
+<pre class="gl-config"><span class="c">// after `brew install` or `go install`</span>
+<span class="p">{</span>
+  <span class="k">"mcpServers"</span>: {
+    <span class="k">"feed-mcp"</span>: {
+      <span class="k">"command"</span>: <span class="s">"feed-mcp"</span>,
+      <span class="k">"args"</span>: [<span class="s">"run"</span>, <span class="s">"https://techcrunch.com/feed/"</span>]
+    }
+  }
+<span class="p">}</span></pre>
+          </div>
+          <div data-gl-panel="opml" hidden>
+<pre class="gl-config"><span class="c">// bring your whole reader — export OPML from Feedly / Inoreader</span>
+<span class="p">{</span>
+  <span class="k">"mcpServers"</span>: {
+    <span class="k">"my-feeds"</span>: {
+      <span class="k">"command"</span>: <span class="s">"docker"</span>,
+      <span class="k">"args"</span>: [
+        <span class="s">"run"</span>, <span class="s">"-i"</span>, <span class="s">"--rm"</span>,
+        <span class="s">"-v"</span>, <span class="s">"/path/to/feeds.opml:/feeds.opml:ro"</span>,
+        <span class="s">"ghcr.io/richardwooding/feed-mcp:latest"</span>,
+        <span class="s">"run"</span>, <span class="s">"--opml"</span>, <span class="s">"/feeds.opml"</span>
+      ]
+    }
+  }
+<span class="p">}</span></pre>
+          </div>
+        </div>
+        <p class="gl-hint">Restart Claude Desktop, then try: <em>"What are the latest tech headlines?"</em> or <em>"Summarize the top 5 articles from my feeds."</em></p>
+      </div>
+    </section>
+
+    <!-- MCP SURFACE -->
+    <section id="surface" class="gl-section">
+      <div class="gl-wrap">
+        <p class="gl-eyebrow">what claude can call</p>
+        <h2>The MCP surface.</h2>
+        <div class="gl-two-col" style="margin-top:24px">
+          <div>
+            <h3 style="font-size:1.05rem;margin-bottom:6px">Tools</h3>
+            <ul class="gl-panel-list">
+              <li><code>all_syndication_feeds</code> — list every configured feed</li>
+              <li><code>get_syndication_feed_items</code> — paginated items with conservative defaults</li>
+              <li><code>fetch_link</code> — pull the full content of a specific article</li>
+              <li><code>add_feed</code> · <code>remove_feed</code> · <code>list_managed_feeds</code> — with <code>--allow-runtime-feeds</code></li>
+            </ul>
+          </div>
+          <div>
+            <h3 style="font-size:1.05rem;margin-bottom:6px">Resources</h3>
+            <ul class="gl-panel-list">
+              <li><code>feeds://all</code> — the full feed catalog</li>
+              <li><code>feeds://feed/{id}</code> — a single feed</li>
+              <li><code>feeds://feed/{id}/items</code> — filter by <code>since</code>, <code>author</code>, <code>category</code>, <code>search</code></li>
+              <li><code>feeds://feed/{id}/meta</code> — feed metadata only</li>
+            </ul>
+          </div>
+        </div>
+        <p class="gl-hint">Item reads default to metadata-only, <code>limit</code> 10 (max 20), to avoid overflowing the conversation context. Opt into <code>includeContent</code> / <code>includeImages</code> when you need more.</p>
+      </div>
+    </section>
+
+    <!-- RESILIENCE -->
+    <section id="resilience" class="gl-section">
+      <div class="gl-wrap">
+        <p class="gl-eyebrow">built to keep serving</p>
+        <h2>Resilience &amp; security, by default.</h2>
+        <div class="gl-grid feat" style="margin-top:28px">
+          <div class="gl-card">
+            <div class="gl-stat">2/s</div>
+            <p style="margin-top:6px">Per-host rate limiting — 2 req/s, burst 5, one limiter per hostname.</p>
+          </div>
+          <div class="gl-card">
+            <div class="gl-stat">3×</div>
+            <p style="margin-top:6px">Retries with exponential backoff + jitter on 5xx, DNS, and timeouts — never on 4xx.</p>
+          </div>
+          <div class="gl-card">
+            <div class="gl-stat">30s</div>
+            <p style="margin-top:6px">Circuit breaker opens after 3 consecutive failures, resets after a 30s timeout.</p>
+          </div>
+          <div class="gl-card">
+            <div class="gl-stat">100</div>
+            <p style="margin-top:6px">Pooled idle connections (10 per host) via a tuned HTTP transport.</p>
+          </div>
+          <div class="gl-card">
+            <div class="gl-stat">SSRF</div>
+            <p style="margin-top:6px">Private IPs blocked up-front and at dial time — DNS-rebinding safe.</p>
+          </div>
+          <div class="gl-card">
+            <div class="gl-stat">SIGTERM</div>
+            <p style="margin-top:6px">Graceful shutdown with context propagation and a configurable timeout.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="gl-section">
+      <div class="gl-wrap" style="text-align:center">
+        <p class="gl-eyebrow" style="justify-content:center">open source · MIT</p>
+        <h2>Give Claude a news habit.</h2>
+        <p class="gl-lede" style="margin:12px auto 24px">Free, self-hostable, and dependency-light. Star it on GitHub or dive into the docs.</p>
+        <div class="gl-cta" style="justify-content:center">
+          <a class="gl-btn primary" href="https://github.com/richardwooding/feed-mcp">Star on GitHub</a>
+          <a class="gl-btn ghost" href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ADVANCED.md">Read the docs</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="gl-footer">
+    <div class="gl-wrap">
+      <span class="gl-brand" style="font-size:.98rem">feed-mcp · MIT · <span data-gl-year></span></span>
+      <nav class="gl-fnav">
+        <a href="https://github.com/richardwooding/feed-mcp">GitHub</a>
+        <a href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+        <a href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ADVANCED.md">Advanced</a>
+        <a href="https://modelcontextprotocol.io">MCP</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="gloam.js" defer></script>
+  <script>
+    // Theme toggle — flips data-theme on <html>, remembers the choice.
+    (function () {
+      var root = document.documentElement;
+      var btn = document.getElementById("theme");
+      try {
+        var saved = localStorage.getItem("gl-theme");
+        if (saved) root.setAttribute("data-theme", saved);
+      } catch (e) { /* ignore */ }
+      if (!btn) return;
+      btn.addEventListener("click", function () {
+        var dark = getComputedStyle(root).getPropertyValue("--gl-bg").trim().indexOf("#0d") === 0
+          || root.getAttribute("data-theme") === "dark";
+        var next = dark ? "light" : "dark";
+        root.setAttribute("data-theme", next);
+        try { localStorage.setItem("gl-theme", next); } catch (e) { /* ignore */ }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -329,9 +329,12 @@
       } catch (e) { /* ignore */ }
       if (!btn) return;
       btn.addEventListener("click", function () {
-        var dark = getComputedStyle(root).getPropertyValue("--gl-bg").trim().indexOf("#0d") === 0
-          || root.getAttribute("data-theme") === "dark";
-        var next = dark ? "light" : "dark";
+        // Resolve the current effective theme: an explicit data-theme wins;
+        // otherwise fall back to the system preference. (Reading the computed
+        // --gl-bg is unreliable — browsers serialize it as rgb(), not hex.)
+        var isDark = root.getAttribute("data-theme") === "dark" ||
+          (!root.getAttribute("data-theme") && !window.matchMedia("(prefers-color-scheme: light)").matches);
+        var next = isDark ? "light" : "dark";
         root.setAttribute("data-theme", next);
         try { localStorage.setItem("gl-theme", next); } catch (e) { /* ignore */ }
       });

--- a/site/index.html
+++ b/site/index.html
@@ -9,11 +9,9 @@
   <meta property="og:description" content="An MCP server that fetches RSS/Atom/JSON feeds and serves them to AI assistants.">
   <meta property="og:type" content="website">
   <link rel="stylesheet" href="gloam.css">
+  <script>try{var t=localStorage.getItem("gl-theme");if(t)document.documentElement.setAttribute("data-theme",t)}catch(e){}</script>
   <style>
     /* page-local extras, all derived from gloam tokens */
-    .gl-theme-toggle { background: var(--gl-panel); color: var(--gl-fg); border: 1px solid var(--gl-border);
-      border-radius: 8px; padding: 8px 10px; cursor: pointer; font: 600 .82rem/1 var(--gl-sans); }
-    .gl-theme-toggle:hover { border-color: var(--gl-accent); }
     .gl-config { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius);
       padding: 16px 18px; overflow-x: auto; font-size: .85rem; line-height: 1.6; margin: 0; font-family: var(--gl-mono); }
     .gl-config .c { color: var(--gl-faint); }
@@ -50,7 +48,10 @@
         <a href="#install">Install</a>
         <a href="#surface">MCP Surface</a>
         <a href="#resilience">Resilience</a>
-        <button class="gl-theme-toggle" id="theme" aria-label="Toggle color theme">◑ Theme</button>
+        <button class="gl-theme-toggle" data-gl-theme-toggle aria-label="Toggle color theme" aria-pressed="true">
+          <svg class="gl-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+          <svg class="gl-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>
+        </button>
         <a class="gl-btn ghost" href="https://github.com/richardwooding/feed-mcp">GitHub ★</a>
       </nav>
     </div>
@@ -318,27 +319,5 @@
   </footer>
 
   <script src="gloam.js" defer></script>
-  <script>
-    // Theme toggle — flips data-theme on <html>, remembers the choice.
-    (function () {
-      var root = document.documentElement;
-      var btn = document.getElementById("theme");
-      try {
-        var saved = localStorage.getItem("gl-theme");
-        if (saved) root.setAttribute("data-theme", saved);
-      } catch (e) { /* ignore */ }
-      if (!btn) return;
-      btn.addEventListener("click", function () {
-        // Resolve the current effective theme: an explicit data-theme wins;
-        // otherwise fall back to the system preference. (Reading the computed
-        // --gl-bg is unreliable — browsers serialize it as rgb(), not hex.)
-        var isDark = root.getAttribute("data-theme") === "dark" ||
-          (!root.getAttribute("data-theme") && !window.matchMedia("(prefers-color-scheme: light)").matches);
-        var next = isDark ? "light" : "dark";
-        root.setAttribute("data-theme", next);
-        try { localStorage.setItem("gl-theme", next); } catch (e) { /* ignore */ }
-      });
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a GitHub Pages landing page for feed-mcp built in the **gloam** design language — dark-first, purple-accented, terminal-flavored — plus a workflow to deploy it.

The page pulls its content straight from the README: what feed-mcp is, why to use it, install methods, the Claude Desktop config, the MCP tool/resource surface, and the resilience & security defaults.

## What's included

- **`site/index.html`** — self-consistent single-page site:
  - Sticky nav with mobile toggle + a persistent light/dark theme toggle
  - Hero with a faux-terminal showing a real `feed-mcp run` session
  - Six-card feature grid
  - Install snippets (brew / go / docker) with copy buttons
  - Tabbed Claude Desktop config (Docker / Homebrew·Go / OPML)
  - MCP surface (tools + resources)
  - Resilience & security stat cards (rate limiting, retries, circuit breaker, pooling, SSRF, graceful shutdown)
- **`site/gloam.css`, `site/gloam.js`** — the gloam design-system assets (MIT)
- **`site/.nojekyll`** — serve as static files, no Jekyll processing
- **`.github/workflows/pages.yml`** — deploys `site/` via `actions/deploy-pages` on push to `main` (path-filtered) and on `workflow_dispatch`

## Enabling Pages

After merge, set **Settings → Pages → Build and deployment → Source = GitHub Actions** (one-time). The workflow then publishes on every change under `site/`.

## Verification

Rendered locally with headless Chrome — layout, terminal, cards, tabs, and copy buttons all render correctly in dark mode; tab/copy/panel wiring verified consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)