### PR TITLE
docs: link footer back to the hub

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -310,6 +310,7 @@
     <div class="gl-wrap">
       <span class="gl-brand" style="font-size:.98rem">feed-mcp · MIT · <span data-gl-year></span></span>
       <nav class="gl-fnav">
+        <a href="https://richardwooding.github.io/">Richard Wooding</a>
         <a href="https://github.com/richardwooding/feed-mcp">GitHub</a>
         <a href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ADVANCED.md">Advanced</a>


### PR DESCRIPTION
Adds a "Richard Wooding" hub backlink as the first item in the footer navigation of the gloam site (`docs/index.html`), linking to https://richardwooding.github.io/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)