### PR TITLE
feat: install Google Tag Manager

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-NB62JPNJ');</script>
+  <!-- End Google Tag Manager -->
   <title>feed-mcp — Bring RSS feeds to Claude</title>
   <meta name="description" content="feed-mcp is a Model Context Protocol server that lets Claude read RSS, Atom, and JSON feeds — with smart caching, rate limiting, circuit breakers, and SSRF protection.">
   <meta property="og:url" content="https://richardwooding.github.io/feed-mcp/">
@@ -40,6 +47,10 @@
   </style>
 </head>
 <body class="gl">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NB62JPNJ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <a class="gl-skip" href="#main">Skip to content</a>
 
   <header class="gl-nav">


### PR DESCRIPTION
Adds the standard GTM container snippet (head loader + `<noscript>` fallback, container `GTM-NB62JPNJ`) to `docs/index.html` for portfolio-wide analytics. Docs-only change; part of the 29-site rollout — feed-mcp goes via PR because of its branch-protection ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)