### PR TITLE
ci: fix CodeQL on Go 1.27 (default setup -> advanced setup)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '41 10 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Must precede codeql/init: the extractor runs the `go` on PATH with
+      # GOTOOLCHAIN=local, and CodeQL's bundled Go lags the go.mod floor.
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
CodeQL default setup runs its own bundled Go — currently 1.26.6 — with `GOTOOLCHAIN=local`, so since `go.mod` moved to the Go 1.27 floor the Go extractor has failed on every run:

```
go: go.mod requires go >= 1.27.0 (running go 1.26.6; GOTOOLCHAIN=local)
Extraction failed for all discovered Go projects.
```

Default setup gives no way to control the toolchain, so this swaps it for an advanced-setup workflow that installs Go from `go.mod` (via `setup-go`, `go-version-file: go.mod`) **before** `codeql-action/init`, putting a matching toolchain on `PATH` for the extractor.

- Default setup has been disabled on the repo; this workflow replaces it.
- Same language coverage as before: `actions`, `go`, `python`.
- Same weekly schedule, plus push/PR on `main`.
- Go uses `build-mode: autobuild`; `actions` and `python` use `build-mode: none`.

This makes Go 1.27 the working default for the project rather than something CodeQL has to tolerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)