### PR TITLE
feat: ask for sponsorship, in the two places people read

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,12 @@ goreleaser release --snapshot --clean
 
 Contributions are welcome! See the [architecture docs](docs/ARCHITECTURE.md) for technical details and development guidelines.
 
+## Sponsor
+
+If this saves you time, you can [sponsor its maintenance](https://github.com/sponsors/richardwooding).
+Sponsorship pays for the unglamorous half — triage, dependency bumps, release plumbing — and is
+never a condition of getting help here.
+
 ## License
 
 MIT License — See [LICENSE](LICENSE) for details.

--- a/docs/index.html
+++ b/docs/index.html
@@ -337,6 +337,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <a href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/richardwooding/feed-mcp/blob/main/docs/ADVANCED.md">Advanced</a>
         <a href="https://modelcontextprotocol.io">MCP</a>
+        <a class="gl-sponsor" href="https://github.com/sponsors/richardwooding">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.7l-1-1.1a5.5 5.5 0 0 0-7.8 7.8L12 21l8.8-8.6a5.5 5.5 0 0 0 0-7.8z"/></svg>
+          Sponsor
+        </a>
       </nav>
     </div>
   </footer>


### PR DESCRIPTION
The [`richardwooding/.github`](https://github.com/richardwooding/.github) default `FUNDING.yml` already gives this repo a Sponsor button, so this is emphasis rather than mechanism — the button sits in the sidebar, while the README is what someone reads in the minute after the project turned out to be useful, and the site footer reaches visitors who never open GitHub.

Wording is byte-identical across the sweep so there is one place to edit if the ask changes. Deliberately no badge: about thirty repos have no badge block at all, and forcing one in for this would read worse than the section does.

The footer link uses gloam's `.gl-sponsor` class, which landed in the last `chore(site): sync gloam design assets`. gloam ships the style; the anchor is the site's own, so an asset sync can never change what a page asks for.

Swept with `scripts/sponsor-sweep.sh` in [richardwooding/.github](https://github.com/richardwooding/.github).